### PR TITLE
feat(authentik): enable self-service password recovery via Mailgun

### DIFF
--- a/infrastructure/controllers/authentik/manifests/blueprints/recovery-flow.yaml
+++ b/infrastructure/controllers/authentik/manifests/blueprints/recovery-flow.yaml
@@ -1,0 +1,23 @@
+version: 1
+metadata:
+  labels:
+    blueprints.goauthentik.io/instantiate: "true"
+  name: Recovery Flow
+
+entries:
+  # =============================================================
+  # Override the default "Recovery Email" stage to use global SMTP
+  # settings (Mailgun) instead of the localhost defaults, and point
+  # to the branded password-reset email template.
+  # =============================================================
+
+  - identifiers:
+      name: Recovery Email
+    model: authentik_stages_email.emailstage
+    state: present
+    attrs:
+      use_global_settings: true
+      template: "email/password_reset_branded.html"
+      subject: "Reset Your Password"
+      activate_user_on_success: true
+      token_expiry: minutes=30

--- a/infrastructure/controllers/authentik/manifests/kustomization.yaml
+++ b/infrastructure/controllers/authentik/manifests/kustomization.yaml
@@ -19,6 +19,7 @@ configMapGenerator:
     files:
       - base.html=templates/base.html
       - account_confirmation_branded.html=templates/account_confirmation_branded.html
+      - password_reset_branded.html=templates/password_reset_branded.html
       - welcome_instructions.html=templates/welcome_instructions.html
   - name: authentik-invitation-blueprint
     files:
@@ -31,3 +32,6 @@ configMapGenerator:
   - name: authentik-branding-blueprint
     files:
       - branding.yaml=blueprints/branding.yaml
+  - name: authentik-recovery-blueprint
+    files:
+      - recovery-flow.yaml=blueprints/recovery-flow.yaml

--- a/infrastructure/controllers/authentik/manifests/templates/password_reset_branded.html
+++ b/infrastructure/controllers/authentik/manifests/templates/password_reset_branded.html
@@ -1,0 +1,40 @@
+{% extends 'email/base.html' %}
+
+{% load authentik_stages_email %}
+
+{% block content %}
+<tr>
+  <td align="center" style="padding: 10px 0 5px 0;">
+    <h2 style="font-size: 20px; color: #F8FAFC; margin: 0;">Reset Your Password</h2>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <table border="0">
+      <tr>
+        <td align="center" style="max-width: 300px; padding: 15px 0; color: #CBD5E1;">
+          We received a request to reset your password. Click the button below to choose a new one.
+        </td>
+      </tr>
+      <tr>
+        <td align="center" class="btn btn-primary">
+          <a id="confirm" href="{{ url }}" rel="noopener noreferrer" target="_blank">Reset Password</a>
+        </td>
+      </tr>
+      <tr>
+        <td align="center" style="padding: 20px 0 0 0; font-size: 12px; color: #94A3B8;">
+          If you didn't request this, you can safely ignore this email.
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}
+
+{% block sub_content %}
+<tr>
+  <td style="padding: 20px; font-size: 12px; color: #94A3B8; word-break: break-all; overflow-wrap: break-word;" align="center">
+    If the button doesn't work, copy this link into your browser: {{ url }}
+  </td>
+</tr>
+{% endblock %}

--- a/infrastructure/controllers/authentik/values.yaml
+++ b/infrastructure/controllers/authentik/values.yaml
@@ -6,6 +6,7 @@ blueprints:
   configMaps:
     - authentik-invitation-blueprint
     - authentik-branding-blueprint
+    - authentik-recovery-blueprint
 global:
   volumes:
     - name: custom-email-templates


### PR DESCRIPTION
## Summary

Enables self-service password recovery by configuring the default Authentik "Recovery Email" stage to use the global Mailgun SMTP settings instead of `localhost:25`.

## Problem

The recovery flow existed with all the correct stages (identification → email → password prompt → write → login), but the "Recovery Email" `EmailStage` was using its default `localhost:25` / `system@authentik.local` configuration. Since no local MTA is running, password reset emails were never delivered — users couldn't reset their own passwords.

## Changes

- **Recovery flow blueprint** (`recovery-flow.yaml`) — overrides the existing "Recovery Email" stage to set `use_global_settings: true` and use the branded template with a 30-minute token expiry
- **Password reset email template** (`password_reset_branded.html`) — extends `base.html` with the Starktastic dark/crimson theme, matching the existing invitation email style
- **Kustomization** — registers the new template in the email ConfigMap and adds the blueprint ConfigMap
- **Helm values** — adds `authentik-recovery-blueprint` to the blueprints list

## Verification

1. Confirm `EmailStage.objects.get(name="Recovery Email").use_global_settings == True`
2. Login page → "Forgot password?" → enter username → verify email arrives via Mailgun
3. Click recovery link → set new password → verify login works