### PR TITLE
chore(ci): harden CI workflows and helper scripts

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,6 +8,7 @@ jobs:
   format:
     name: Format all YAML, JSON and shell files
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -16,7 +17,7 @@ jobs:
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
-          token: ${{ secrets.ORG_DISPATCH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prettier
         uses: creyD/prettier_action@v4.6

--- a/.github/workflows/refresh.yaml
+++ b/.github/workflows/refresh.yaml
@@ -5,10 +5,15 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: argocd-refresh
+  cancel-in-progress: false
+
 jobs:
   refresh:
     name: Trigger refresh
     runs-on: self-hosted
+    timeout-minutes: 10
     container:
       image: buildpack-deps:scm
     defaults:
@@ -148,7 +153,8 @@ jobs:
 
       - name: Setup ArgoCD CLI
         if: steps.guard.outputs.scope != 'skip'
-        uses: clowdhaus/argo-cd-action@main
+        # renovate: datasource=github-tags depName=clowdhaus/argo-cd-action
+        uses: clowdhaus/argo-cd-action@b7274e53d135aa3f2c8cc1154420cf11e39e67db  # main
         with:
           command: version
           options: --client

--- a/.github/workflows/validate-and-diff.yml
+++ b/.github/workflows/validate-and-diff.yml
@@ -17,6 +17,7 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -25,7 +26,9 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.x'
-          pip-install: 'yamllint'
+
+      - name: Install yamllint
+        run: pip install yamllint
 
       - name: YAML Lint
         id: yamllint
@@ -125,6 +128,7 @@ jobs:
     needs: validate
     if: always() && !cancelled()
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v6
@@ -138,6 +142,11 @@ jobs:
           path: main
 
       - name: Generate diff
+        # argocd-diff-preview spins up an ephemeral k3d cluster in Docker to
+        # render real ArgoCD Application manifests, so it needs Docker access.
+        # Mounting /var/run/docker.sock here is safe because this workflow uses
+        # `pull_request` (not `pull_request_target`) — PR code cannot read
+        # repository secrets.
         env:
           # renovate: datasource=docker depName=dagandersen/argocd-diff-preview
           DIFF_PREVIEW_VERSION: 'v0.2.8'
@@ -168,6 +177,7 @@ jobs:
     needs: [validate, diff]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
       "allowedVersions": "!/^\\d{2}\\.04/"
     },
     {
-      "description": "Block old LinuxServer libtorrent-based tags for qBittorrent",
+      "description": "Stay on libtorrent v2 (qBittorrent 5.x); block the 6.x release which switches to libtorrent v3",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["lscr.io/linuxserver/qbittorrent"],
       "allowedVersions": "< 6.0.0"

--- a/scripts/get-kubeconfig.sh
+++ b/scripts/get-kubeconfig.sh
@@ -11,7 +11,7 @@ echo "🔌 Fetching Kubeconfig from $HOST..."
 
 # 1. SSH, cat the file (sudo), replace IP, and write to a temp file
 TMP_CONFIG=$(mktemp)
-ssh -o StrictHostKeyChecking=no -i "$KEY" "$USER@$HOST" \
+ssh -o StrictHostKeyChecking=accept-new -i "$KEY" "$USER@$HOST" \
   "sudo cat /etc/rancher/k3s/k3s.yaml" |
   sed "s/127.0.0.1/$HOST/g" >"$TMP_CONFIG"
 

--- a/scripts/seal.sh
+++ b/scripts/seal.sh
@@ -29,9 +29,15 @@ fi
 
 echo " Enter your key-value pairs (e.g. password=SuperSecret). Press Ctrl+D when done."
 
+STDIN_BUFFER=$(cat)
+if [[ -z $STDIN_BUFFER ]]; then
+  echo "❌ Error: No key-value pairs provided on stdin. Aborting." >&2
+  exit 1
+fi
+
 kubectl create secret generic "$SECRET_NAME" \
   --namespace "$NAMESPACE" \
-  --from-env-file /dev/stdin \
+  --from-env-file=<(echo "$STDIN_BUFFER") \
   --dry-run=client \
   -o yaml |
   kubeseal \


### PR DESCRIPTION
PR 4 of the polish series. A grab-bag of CI/tooling improvements found during the repo review. No behavioural change to any deployed application.

## CI workflows
- **`validate-and-diff.yml`**
  - Replace the **silently-ignored** `pip-install: 'yamllint'` parameter on `actions/setup-python` (not a real input — verified against upstream docs) with an explicit `pip install yamllint` step. Deterministic regardless of runner image.
  - Add `timeout-minutes` to all three jobs (validate=15, diff=15, report=5).
  - Document **why** the diff job mounts `/var/run/docker.sock`: `argocd-diff-preview` spawns an ephemeral k3d cluster to render real ArgoCD manifests. Safe here because the workflow trigger is `pull_request` (not `pull_request_target`), so PR code cannot read repo secrets.
- **`format.yaml`**
  - Switch from the `ORG_DISPATCH_TOKEN` PAT to the built-in `GITHUB_TOKEN`. Auto-formatter doesn't need to bypass branch protection or fan out downstream workflows.
  - Add `timeout-minutes: 10`.
- **`refresh.yaml`**
  - Add a `concurrency` group (`argocd-refresh`, `cancel-in-progress: false`) so two pushes in quick succession serialize their ArgoCD refresh calls instead of racing each other.
  - Pin `clowdhaus/argo-cd-action` from `@main` to an immutable SHA, with a Renovate annotation to keep it updated.
  - Add `timeout-minutes: 10`.

## Scripts
- **`get-kubeconfig.sh`** — change SSH `StrictHostKeyChecking=no` → `accept-new`. First connection still works without prompting; subsequent connections detect host-key changes (TOFU model).
- **`seal.sh`** — refuse to run when stdin is empty. Previously an accidental Ctrl+D with no input produced an empty SealedSecret file silently.

## Renovate
- Rewrite the qBittorrent rule description to actually explain what the cap is for: *stay on libtorrent v2 (qBittorrent 5.x); block 6.x which switches to libtorrent v3.*

## Compatibility
- Independent of PR #722 (gitops-engine polish) — can merge in either order.