### PR TITLE
fix(security): postgres init container, traefik api note, crowdsec TLS TODO

### DIFF
--- a/infrastructure/configs/templates/crowdsec/middleware-bouncer.yaml
+++ b/infrastructure/configs/templates/crowdsec/middleware-bouncer.yaml
@@ -12,4 +12,9 @@ spec:
       crowdsecLapiScheme: https
       crowdsecLapiHost: crowdsec-service.crowdsec.svc.cluster.local:8080
       crowdsecLapiKeyFile: /etc/crowdsec/bouncer-key
+      # NOTE: requires manual setup before this can be flipped to `false`:
+      # mount the cert-manager-issued bouncer CA cert into Traefik (as a
+      # secret volume) and add `crowdsecLapiTLSCertificateAuthorityFile`
+      # pointing at the mount path. Until then we rely on the pre-shared
+      # bouncer API key plus the in-cluster network for authentication.
       crowdsecLapiTLSInsecureVerify: true

--- a/infrastructure/controllers/databases/postgres/values.yaml
+++ b/infrastructure/controllers/databases/postgres/values.yaml
@@ -36,7 +36,10 @@ primary:
       image: busybox:latest
       imagePullPolicy: IfNotPresent
       securityContext:
-        runAsUser: 0
+        # Match the main container's uid/gid so we don't need to escalate to
+        # root just to delete a single file that's owned by postgres.
+        runAsUser: 1001
+        runAsNonRoot: true
       command:
         - sh
         - -c

--- a/infrastructure/controllers/traefik/values.yaml
+++ b/infrastructure/controllers/traefik/values.yaml
@@ -82,6 +82,10 @@ ingressClass:
   isDefaultClass: true
 api:
   dashboard: true
+  # `insecure: true` exposes Traefik's API on port 8080 inside the pod — NOT
+  # publicly. It's the standard way to back the in-cluster IngressRoute that
+  # serves the dashboard at traefik.internal (which itself is gated by
+  # Authentik forward-auth + the internal-ip-allowlist middleware).
   insecure: true
 ingressRoute:
   dashboard:


### PR DESCRIPTION
PR 3 of the polish series. **Depends on #722.**

Three small hardening changes plus a clearer note on the one item that needs hands-on cluster work to finish.

## 1. Postgres init container — drop root escalation
The `rm-postmaster-lock-file` init container previously ran as `runAsUser: 0` to delete a single file inside the data PVC. That file is owned by uid 1001 (the postgres user), so running the init as 1001 + `runAsNonRoot: true` works just as well without escalating. Removes the only place we run as root for a non-system reason.

## 2. Traefik `api.insecure: true` — add justifying comment
Adds an inline comment explaining that this flag only exposes the API on port 8080 *inside* the pod and is the standard way to back the in-cluster IngressRoute that serves the dashboard. The external surface is still gated by Authentik forward-auth + internal-ip-allowlist.

## 3. CrowdSec bouncer TLS — annotate the existing gap
The bouncer middleware sets `crowdsecLapiTLSInsecureVerify: true` even though cert-manager issues real certs for the LAPI service. Properly flipping to `false` requires mounting the bouncer CA cert into Traefik (as a secret volume) and adding `crowdsecLapiTLSCertificateAuthorityFile`. That needs cluster-side testing — this PR just adds a TODO + explanation so the flag isn't unjustified.

## What was *not* included
Resource requests/limits for bare controllers (traefik, authentik, metallb, cert-manager) were considered but deliberately deferred — setting speculative limits without observed-usage metrics is more likely to cause OOM-kills than to harden anything in a homelab. Better done with actual metrics in a follow-up.