### PR TITLE
refactor(services): tidy *arr family for consistency

### DIFF
--- a/services/media/lidarr/values.yaml
+++ b/services/media/lidarr/values.yaml
@@ -11,10 +11,6 @@ controllers:
             type: HTTP
             path: /ping
             port: 8686
-            spec:
-              timeoutSeconds: 10
-              failureThreshold: 10
-              periodSeconds: 30
           readiness:
             enabled: true
             type: HTTP

--- a/services/media/prowlarr/app.yaml
+++ b/services/media/prowlarr/app.yaml
@@ -2,6 +2,8 @@ name: prowlarr
 namespace: media
 deployPhase: services
 
+# Prowlarr is an indexer manager — it never touches the media library, so
+# unlike the other *arr services this one doesn't enable persistence.media.
 ingress:
   enabled: true
   host: prowlarr

--- a/services/media/radarr-ru/app.yaml
+++ b/services/media/radarr-ru/app.yaml
@@ -3,10 +3,9 @@ namespace: media
 deployPhase: services
 baseApp: services/media/radarr
 
+# Inherits all ingress fields from the base radarr app.yaml; only the host
+# differs (PR-based variant ingress override loads base app.yaml first, then
+# variant's, in the ingress chart).
 ingress:
   enabled: true
   host: radarr-ru
-  domainType: "internal"
-  port: 7878
-  auth: true
-  rateLimit: true

--- a/services/media/seerr-ru/app.yaml
+++ b/services/media/seerr-ru/app.yaml
@@ -6,7 +6,3 @@ baseApp: services/media/seerr
 ingress:
   enabled: true
   host: "request-ru"
-  domainType: "media"
-  port: 5055
-  auth: false
-  rateLimit: true

--- a/services/media/sonarr-ru/app.yaml
+++ b/services/media/sonarr-ru/app.yaml
@@ -6,7 +6,3 @@ baseApp: services/media/sonarr
 ingress:
   enabled: true
   host: sonarr-ru
-  domainType: "internal"
-  port: 8989
-  auth: true
-  rateLimit: true


### PR DESCRIPTION
Part 5 of the polish series. Depends on #722 (variant ingress override mechanism).

## Changes

### Slim `-ru` variants (#19 from review)
`radarr-ru`, `sonarr-ru`, `seerr-ru` previously duplicated every
ingress field from their base app. With #722's variant ingress
override (base `app.yaml` loaded first, then variant), the variants
now only override `ingress.host` — everything else is inherited.

### Lidarr probe timings (#21)
Removed bespoke `timeoutSeconds: 10, failureThreshold: 10,
periodSeconds: 30` from lidarr liveness probe. The values diverged
from every other *arr service for no documented reason; falls back
to the common.yaml defaults like its siblings.

### Prowlarr documentation (#22)
Added a comment explaining that prowlarr (an indexer manager) does
not enable `persistence.media` — unlike the other *arr services.

## Verification
`argocd-diff-preview` should show no Application changes beyond
the inherited fields rendering identically to the previously-explicit
ones (modulo ordering).