### PR TITLE
refactor(media): DRY the *arr family with commonValuesExtras

### DIFF
--- a/services/media/bazarr/app.yaml
+++ b/services/media/bazarr/app.yaml
@@ -2,6 +2,8 @@ name: bazarr
 namespace: media
 deployPhase: services
 manifests: true
+commonValuesExtras:
+  - templates/media-arr-common.yaml
 
 ingress:
   enabled: true

--- a/services/media/bazarr/values.yaml
+++ b/services/media/bazarr/values.yaml
@@ -9,10 +9,12 @@ controllers:
           - secretRef:
               name: bazarr-secret
         probes:
-          liveness: { port: 6767 }
-          readiness: { port: 6767 }
-          startup: { port: 6767 }
-
+          liveness:
+            port: 6767
+          readiness:
+            port: 6767
+          startup:
+            port: 6767
 service:
   main:
     ports:

--- a/services/media/bazarr/values.yaml
+++ b/services/media/bazarr/values.yaml
@@ -9,9 +9,9 @@ controllers:
           - secretRef:
               name: bazarr-secret
         probes:
-          liveness: {port: 6767}
-          readiness: {port: 6767}
-          startup: {port: 6767}
+          liveness: { port: 6767 }
+          readiness: { port: 6767 }
+          startup: { port: 6767 }
 
 service:
   main:

--- a/services/media/bazarr/values.yaml
+++ b/services/media/bazarr/values.yaml
@@ -9,9 +9,9 @@ controllers:
           - secretRef:
               name: bazarr-secret
         probes:
-          liveness: { port: 6767 }
-          readiness: { port: 6767 }
-          startup: { port: 6767 }
+          liveness: {port: 6767}
+          readiness: {port: 6767}
+          startup: {port: 6767}
 
 service:
   main:

--- a/services/media/bazarr/values.yaml
+++ b/services/media/bazarr/values.yaml
@@ -9,9 +9,9 @@ controllers:
           - secretRef:
               name: bazarr-secret
         probes:
-          liveness:   { port: 6767 }
-          readiness:  { port: 6767 }
-          startup:    { port: 6767 }
+          liveness: { port: 6767 }
+          readiness: { port: 6767 }
+          startup: { port: 6767 }
 
 service:
   main:

--- a/services/media/bazarr/values.yaml
+++ b/services/media/bazarr/values.yaml
@@ -9,25 +9,12 @@ controllers:
           - secretRef:
               name: bazarr-secret
         probes:
-          liveness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 6767
-          readiness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 6767
-          startup:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 6767
+          liveness:   { port: 6767 }
+          readiness:  { port: 6767 }
+          startup:    { port: 6767 }
 
 service:
   main:
-    controller: main
     ports:
       http:
         port: 6767
@@ -39,5 +26,3 @@ persistence:
     defaultMode: 0755
     globalMounts:
       - path: /scripts
-  media:
-    enabled: true

--- a/services/media/lidarr/app.yaml
+++ b/services/media/lidarr/app.yaml
@@ -1,6 +1,8 @@
 name: lidarr
 namespace: media
 deployPhase: services
+commonValuesExtras:
+  - templates/media-arr-common.yaml
 
 ingress:
   enabled: true

--- a/services/media/lidarr/values.yaml
+++ b/services/media/lidarr/values.yaml
@@ -6,10 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/lidarr
           tag: 3.1.0.4875-ls22@sha256:dbffcf91da47d48e09e613857032c95a62755b928a71a7718688e3ab03fbbd26
         probes:
-          liveness: { port: 8686 }
-          readiness: { port: 8686 }
-          startup: { port: 8686 }
-
+          liveness:
+            port: 8686
+          readiness:
+            port: 8686
+          startup:
+            port: 8686
 service:
   main:
     ports:

--- a/services/media/lidarr/values.yaml
+++ b/services/media/lidarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/lidarr
           tag: 3.1.0.4875-ls22@sha256:dbffcf91da47d48e09e613857032c95a62755b928a71a7718688e3ab03fbbd26
         probes:
-          liveness: { port: 8686 }
-          readiness: { port: 8686 }
-          startup: { port: 8686 }
+          liveness: {port: 8686}
+          readiness: {port: 8686}
+          startup: {port: 8686}
 
 service:
   main:

--- a/services/media/lidarr/values.yaml
+++ b/services/media/lidarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/lidarr
           tag: 3.1.0.4875-ls22@sha256:dbffcf91da47d48e09e613857032c95a62755b928a71a7718688e3ab03fbbd26
         probes:
-          liveness:   { port: 8686 }
-          readiness:  { port: 8686 }
-          startup:    { port: 8686 }
+          liveness: { port: 8686 }
+          readiness: { port: 8686 }
+          startup: { port: 8686 }
 
 service:
   main:

--- a/services/media/lidarr/values.yaml
+++ b/services/media/lidarr/values.yaml
@@ -6,29 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/lidarr
           tag: 3.1.0.4875-ls22@sha256:dbffcf91da47d48e09e613857032c95a62755b928a71a7718688e3ab03fbbd26
         probes:
-          liveness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 8686
-          readiness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 8686
-          startup:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 8686
+          liveness:   { port: 8686 }
+          readiness:  { port: 8686 }
+          startup:    { port: 8686 }
 
 service:
   main:
-    controller: main
     ports:
       http:
         port: 8686
-
-persistence:
-  media:
-    enabled: true

--- a/services/media/lidarr/values.yaml
+++ b/services/media/lidarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/lidarr
           tag: 3.1.0.4875-ls22@sha256:dbffcf91da47d48e09e613857032c95a62755b928a71a7718688e3ab03fbbd26
         probes:
-          liveness: {port: 8686}
-          readiness: {port: 8686}
-          startup: {port: 8686}
+          liveness: { port: 8686 }
+          readiness: { port: 8686 }
+          startup: { port: 8686 }
 
 service:
   main:

--- a/services/media/prowlarr/app.yaml
+++ b/services/media/prowlarr/app.yaml
@@ -1,9 +1,12 @@
 name: prowlarr
 namespace: media
 deployPhase: services
+commonValuesExtras:
+  - templates/media-arr-common.yaml
 
 # Prowlarr is an indexer manager — it never touches the media library, so
-# unlike the other *arr services this one doesn't enable persistence.media.
+# unlike the other *arr services this one overrides persistence.media.enabled
+# to false in its values.yaml.
 ingress:
   enabled: true
   host: prowlarr

--- a/services/media/prowlarr/values.yaml
+++ b/services/media/prowlarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/prowlarr
           tag: 2.3.5@sha256:c9fe528f34b1fd3715438b6f6d6991d64e2965f2c055db36398bc66a0e7eab01
         probes:
-          liveness: { port: 9696 }
-          readiness: { port: 9696 }
-          startup: { port: 9696 }
+          liveness: {port: 9696}
+          readiness: {port: 9696}
+          startup: {port: 9696}
 
 service:
   main:

--- a/services/media/prowlarr/values.yaml
+++ b/services/media/prowlarr/values.yaml
@@ -6,25 +6,18 @@ controllers:
           repository: lscr.io/linuxserver/prowlarr
           tag: 2.3.5@sha256:c9fe528f34b1fd3715438b6f6d6991d64e2965f2c055db36398bc66a0e7eab01
         probes:
-          liveness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 9696
-          readiness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 9696
-          startup:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 9696
+          liveness:   { port: 9696 }
+          readiness:  { port: 9696 }
+          startup:    { port: 9696 }
 
 service:
   main:
-    controller: main
     ports:
       http:
         port: 9696
+
+# Prowlarr is an indexer manager and does not need the shared media library
+# mounted by the common *arr extras (templates/media-arr-common.yaml).
+persistence:
+  media:
+    enabled: false

--- a/services/media/prowlarr/values.yaml
+++ b/services/media/prowlarr/values.yaml
@@ -6,10 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/prowlarr
           tag: 2.3.5@sha256:c9fe528f34b1fd3715438b6f6d6991d64e2965f2c055db36398bc66a0e7eab01
         probes:
-          liveness: { port: 9696 }
-          readiness: { port: 9696 }
-          startup: { port: 9696 }
-
+          liveness:
+            port: 9696
+          readiness:
+            port: 9696
+          startup:
+            port: 9696
 service:
   main:
     ports:

--- a/services/media/prowlarr/values.yaml
+++ b/services/media/prowlarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/prowlarr
           tag: 2.3.5@sha256:c9fe528f34b1fd3715438b6f6d6991d64e2965f2c055db36398bc66a0e7eab01
         probes:
-          liveness:   { port: 9696 }
-          readiness:  { port: 9696 }
-          startup:    { port: 9696 }
+          liveness: { port: 9696 }
+          readiness: { port: 9696 }
+          startup: { port: 9696 }
 
 service:
   main:

--- a/services/media/prowlarr/values.yaml
+++ b/services/media/prowlarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/prowlarr
           tag: 2.3.5@sha256:c9fe528f34b1fd3715438b6f6d6991d64e2965f2c055db36398bc66a0e7eab01
         probes:
-          liveness: {port: 9696}
-          readiness: {port: 9696}
-          startup: {port: 9696}
+          liveness: { port: 9696 }
+          readiness: { port: 9696 }
+          startup: { port: 9696 }
 
 service:
   main:

--- a/services/media/radarr/app.yaml
+++ b/services/media/radarr/app.yaml
@@ -1,6 +1,8 @@
 name: radarr
 namespace: media
 deployPhase: services
+commonValuesExtras:
+  - templates/media-arr-common.yaml
 
 ingress:
   enabled: true

--- a/services/media/radarr/values.yaml
+++ b/services/media/radarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/radarr
           tag: 6.1.1@sha256:079e48870584baf2a3e7e43e7ba6d3c834555931851a59c82c51cc792d285caf
         probes:
-          liveness:   { port: 7878 }
-          readiness:  { port: 7878 }
-          startup:    { port: 7878 }
+          liveness: { port: 7878 }
+          readiness: { port: 7878 }
+          startup: { port: 7878 }
 
 service:
   main:

--- a/services/media/radarr/values.yaml
+++ b/services/media/radarr/values.yaml
@@ -6,10 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/radarr
           tag: 6.1.1@sha256:079e48870584baf2a3e7e43e7ba6d3c834555931851a59c82c51cc792d285caf
         probes:
-          liveness: { port: 7878 }
-          readiness: { port: 7878 }
-          startup: { port: 7878 }
-
+          liveness:
+            port: 7878
+          readiness:
+            port: 7878
+          startup:
+            port: 7878
 service:
   main:
     ports:

--- a/services/media/radarr/values.yaml
+++ b/services/media/radarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/radarr
           tag: 6.1.1@sha256:079e48870584baf2a3e7e43e7ba6d3c834555931851a59c82c51cc792d285caf
         probes:
-          liveness: { port: 7878 }
-          readiness: { port: 7878 }
-          startup: { port: 7878 }
+          liveness: {port: 7878}
+          readiness: {port: 7878}
+          startup: {port: 7878}
 
 service:
   main:

--- a/services/media/radarr/values.yaml
+++ b/services/media/radarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/radarr
           tag: 6.1.1@sha256:079e48870584baf2a3e7e43e7ba6d3c834555931851a59c82c51cc792d285caf
         probes:
-          liveness: {port: 7878}
-          readiness: {port: 7878}
-          startup: {port: 7878}
+          liveness: { port: 7878 }
+          readiness: { port: 7878 }
+          startup: { port: 7878 }
 
 service:
   main:

--- a/services/media/radarr/values.yaml
+++ b/services/media/radarr/values.yaml
@@ -6,29 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/radarr
           tag: 6.1.1@sha256:079e48870584baf2a3e7e43e7ba6d3c834555931851a59c82c51cc792d285caf
         probes:
-          liveness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 7878
-          readiness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 7878
-          startup:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 7878
+          liveness:   { port: 7878 }
+          readiness:  { port: 7878 }
+          startup:    { port: 7878 }
 
 service:
   main:
-    controller: main
     ports:
       http:
         port: 7878
-
-persistence:
-  media:
-    enabled: true

--- a/services/media/sonarr/app.yaml
+++ b/services/media/sonarr/app.yaml
@@ -1,6 +1,8 @@
 name: sonarr
 namespace: media
 deployPhase: services
+commonValuesExtras:
+  - templates/media-arr-common.yaml
 
 ingress:
   enabled: true

--- a/services/media/sonarr/values.yaml
+++ b/services/media/sonarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/sonarr
           tag: 4.0.17@sha256:0b5c4803f92456fb9b65bae8375716ea120b4ea17b3cced7da32b63f0085782b
         probes:
-          liveness:   { port: 8989 }
-          readiness:  { port: 8989 }
-          startup:    { port: 8989 }
+          liveness: { port: 8989 }
+          readiness: { port: 8989 }
+          startup: { port: 8989 }
 
 service:
   main:

--- a/services/media/sonarr/values.yaml
+++ b/services/media/sonarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/sonarr
           tag: 4.0.17@sha256:0b5c4803f92456fb9b65bae8375716ea120b4ea17b3cced7da32b63f0085782b
         probes:
-          liveness: {port: 8989}
-          readiness: {port: 8989}
-          startup: {port: 8989}
+          liveness: { port: 8989 }
+          readiness: { port: 8989 }
+          startup: { port: 8989 }
 
 service:
   main:

--- a/services/media/sonarr/values.yaml
+++ b/services/media/sonarr/values.yaml
@@ -6,10 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/sonarr
           tag: 4.0.17@sha256:0b5c4803f92456fb9b65bae8375716ea120b4ea17b3cced7da32b63f0085782b
         probes:
-          liveness: { port: 8989 }
-          readiness: { port: 8989 }
-          startup: { port: 8989 }
-
+          liveness:
+            port: 8989
+          readiness:
+            port: 8989
+          startup:
+            port: 8989
 service:
   main:
     ports:

--- a/services/media/sonarr/values.yaml
+++ b/services/media/sonarr/values.yaml
@@ -6,29 +6,12 @@ controllers:
           repository: lscr.io/linuxserver/sonarr
           tag: 4.0.17@sha256:0b5c4803f92456fb9b65bae8375716ea120b4ea17b3cced7da32b63f0085782b
         probes:
-          liveness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 8989
-          readiness:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 8989
-          startup:
-            enabled: true
-            type: HTTP
-            path: /ping
-            port: 8989
+          liveness:   { port: 8989 }
+          readiness:  { port: 8989 }
+          startup:    { port: 8989 }
 
 service:
   main:
-    controller: main
     ports:
       http:
         port: 8989
-
-persistence:
-  media:
-    enabled: true

--- a/services/media/sonarr/values.yaml
+++ b/services/media/sonarr/values.yaml
@@ -6,9 +6,9 @@ controllers:
           repository: lscr.io/linuxserver/sonarr
           tag: 4.0.17@sha256:0b5c4803f92456fb9b65bae8375716ea120b4ea17b3cced7da32b63f0085782b
         probes:
-          liveness: { port: 8989 }
-          readiness: { port: 8989 }
-          startup: { port: 8989 }
+          liveness: {port: 8989}
+          readiness: {port: 8989}
+          startup: {port: 8989}
 
 service:
   main:

--- a/templates/media-arr-common.yaml
+++ b/templates/media-arr-common.yaml
@@ -1,0 +1,34 @@
+# Shared bjw-s app-template values for the *arr family (sonarr, radarr,
+# lidarr, prowlarr, bazarr). Loaded via `commonValuesExtras` from each
+# service's app.yaml, before the service's own values.yaml.
+#
+# Per-service values.yaml still owns:
+#   - controllers.main.containers.main.image
+#   - probe ports (liveness/readiness/startup) and service.main.ports.http.port
+#   - service-specific extras (e.g. bazarr's envFrom and scripts mount,
+#     prowlarr's persistence.media.enabled: false override)
+controllers:
+  main:
+    containers:
+      main:
+        probes:
+          liveness:
+            enabled: true
+            type: HTTP
+            path: /ping
+          readiness:
+            enabled: true
+            type: HTTP
+            path: /ping
+          startup:
+            enabled: true
+            type: HTTP
+            path: /ping
+
+service:
+  main:
+    controller: main
+
+persistence:
+  media:
+    enabled: true


### PR DESCRIPTION
Part 6 (final) of the polish series. Depends on #722 (introduces the `commonValuesExtras` field) and overlaps cleanly with #728 (lidarr probe normalization — both PRs converge to the same end state).

## Why
The five *arr services (sonarr, radarr, lidarr, prowlarr, bazarr) all
shipped the same bjw-s app-template scaffolding repeated five times:
identical `/ping` HTTP probe shapes × 3 probes each, identical
service:main controller binding, identical persistence.media. Net 64
lines removed.

## How
1. New `templates/media-arr-common.yaml` holds the shared shape (probe
   spec without port, service controller binding, persistence.media).
2. Each *arr `app.yaml` adds:
   ```yaml
   commonValuesExtras:
     - templates/media-arr-common.yaml
   ```
3. Each `values.yaml` keeps only what's unique: image, port (probes
   + service), and service-specific extras (bazarr's envFrom +
   scripts mount; prowlarr's `persistence.media.enabled: false`
   override).

## Verification
Rendered `helm template` output is byte-identical before and after
for all five services (modulo lidarr's probe-timing normalization,
which is the same end state as #728).