### PR TITLE
hotfix: ignore PVC storageClassName drift after default-SC swap

### DIFF
--- a/bootstrap/appsets/cluster-apps.yaml
+++ b/bootstrap/appsets/cluster-apps.yaml
@@ -80,6 +80,7 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: 30
           backoff:
@@ -91,6 +92,14 @@ spec:
           kind: Secret
           jsonPointers:
             - /data
+        - group: ""
+          kind: PersistentVolumeClaim
+          jsonPointers:
+            # PVC spec is immutable post-bind. We dropped the explicit
+            # `storageClassName: nfs-pv` from values now that nfs-pv is the
+            # sole cluster default, but bound PVCs still report it on the
+            # live side, which Argo would otherwise flag as drift forever.
+            - /spec/storageClassName
         - group: apps
           kind: Deployment
           jqPathExpressions:


### PR DESCRIPTION
## Symptom (post-#726)
Every app with a pre-existing PVC is stuck `OutOfSync` with:

```
PersistentVolumeClaim ... is invalid: spec: Forbidden: spec is immutable
after creation except resources.requests and volumeAttributesClassName
for bound claims
```

## Cause
#726 dropped `storageClassName: nfs-pv` from PVC manifests and Helm
values, relying on `nfs-pv` being the sole cluster-default. The default
correctly fills in for **new** PVCs, but **bound** PVCs still report
`storageClassName: nfs-pv` on the live side (the field is immutable
post-bind). Argo's ServerSideApply tried to delete the field → API
server rejected.

## Fix
1. Add `/spec/storageClassName` for `PersistentVolumeClaim` to
   `ignoreDifferences` at the AppSet level.
2. Add `RespectIgnoreDifferences=true` to syncOptions so the ignored
   field is **merged from live state into the desired manifest before
   apply**, not just hidden in the diff UI.

## Data safety
No data loss possible: PVs are `reclaimPolicy: Retain`, all bindings
intact, no PV/PVC was ever deleted. The API server's immutability
guard is exactly the failsafe that protected the data.

## After merge
```bash
argocd app list -o wide | grep -v 'Synced.*Healthy'   # should drain quickly
```