### PR TITLE
hotfix: re-pin loki/tempo storageClass + extend ignoreDifferences to config-apps

### DIFF
--- a/bootstrap/appsets/config-apps.yaml
+++ b/bootstrap/appsets/config-apps.yaml
@@ -62,9 +62,18 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: 30
           backoff:
             duration: 15s
             factor: 2
             maxDuration: 5m
+      ignoreDifferences:
+        - group: ""
+          kind: PersistentVolumeClaim
+          jsonPointers:
+            # See cluster-apps.yaml for the rationale (PVC spec.storageClassName
+            # is immutable post-bind, but dropped from desired manifests now
+            # that nfs-pv is the sole cluster default).
+            - /spec/storageClassName

--- a/services/operations/loki/values.yaml
+++ b/services/operations/loki/values.yaml
@@ -32,6 +32,11 @@ singleBinary:
   replicas: 1
   persistence:
     enabled: true
+    # Must stay explicit: loki ships as a StatefulSet, and once
+    # volumeClaimTemplates.storageClassName is set on a live STS it is
+    # immutable. Leaving this empty would render a different VCT spec
+    # and the apply would be rejected.
+    storageClass: nfs-pv
     size: 10Gi
 
 read:

--- a/services/operations/tempo/values.yaml
+++ b/services/operations/tempo/values.yaml
@@ -26,6 +26,10 @@ tempo:
 
 persistence:
   enabled: true
+  # Must stay explicit: tempo ships as a StatefulSet, and once
+  # volumeClaimTemplates.storageClassName is set on a live STS it is
+  # immutable.
+  storageClassName: nfs-pv
   accessModes:
     - ReadWriteMany
   size: 5Gi


### PR DESCRIPTION
Two follow-ups to #726 + #730 — three apps remained stuck after #730.

## 1. loki and tempo StatefulSets

Unlike Deployments+PVCs, an STS's `volumeClaimTemplates.storageClassName`
is immutable post-creation, so `ignoreDifferences` on PVCs doesn't help
— Argo would still need to send a different STS spec, and the API server
rejects it:

```
StatefulSet.apps "loki" is invalid: spec: Forbidden: updates to
statefulset spec for fields other than 'replicas', 'ordinals',
'template', 'updateStrategy', 'revisionHistoryLimit',
'persistentVolumeClaimRetentionPolicy' and 'minReadySeconds' are
forbidden
```

Re-pin `storageClass: nfs-pv` (loki) and `storageClassName: nfs-pv`
(tempo) in their values.yaml with a comment explaining why the
explicit value must stay.

## 2. config-apps AppSet

#730 added the PVC `ignoreDifferences` + `RespectIgnoreDifferences=true`
to `cluster-apps.yaml` only. The `config-apps` AppSet (manages
`base-configs`, `infra-configs`) hit the same immutability error on
`cert-backup` and `pg-backup` PVCs. Mirror the fix in `config-apps.yaml`.

## Data safety
No data loss — the immutability guards in K8s protected both the PVs
and the STS data throughout.