### PR TITLE
chore(renovate): group authentik chart and outpost images into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,11 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["lscr.io/linuxserver/qbittorrent"],
       "allowedVersions": "< 6.0.0"
+    },
+    {
+      "description": "Group the Authentik Helm chart and its outpost docker images into a single PR — they release in lockstep and must be upgraded together",
+      "matchPackageNames": ["authentik", "/^ghcr\\.io/goauthentik//"],
+      "groupName": "authentik"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
## Why

Renovate currently opens a separate PR for each Authentik artifact:
- #715 — `authentik` helm chart → v2026.5.0
- #720 — `ghcr.io/goauthentik/ldap` docker image → v2026.5.0

The chart and the outpost images are released in lockstep (same version tag) and **must** be upgraded together to avoid CRD/API mismatches between the server and its outposts.

## What

Adds a packageRule that groups any `authentik` chart and any `ghcr.io/goauthentik/*` image (covers ldap today, future outposts like proxy/radius automatically) under a single `authentik` group, so Renovate will open one combined PR going forward.

## Verification

```bash
python3 -c 'import json; json.load(open("renovate.json"))'  # JSON valid
```

After merge, close #715 and #720; Renovate will open a fresh combined PR on its next scan.