### PR TITLE
fix(recyclarr): prefer P8 hybrid remuxes over P7 FEL on main instances

### DIFF
--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -53,6 +53,15 @@ data:
 
         custom_format_groups:
           add:
+            # Release-group tier scoring for Remux / UHD Bluray / HD Bluray /
+            # WEB. Not default-synced (natural include is only Base Profile),
+            # so explicitly assigned to our profile. The profile's own
+            # formatItems already scores UHD Bluray + WEB tiers; this group
+            # adds Remux Tier 01/02/03 (+1950/+1900/+1850) so elite remux
+            # groups (FraMeSToR, BiZKiT, BMF, ...) outscore generic remuxes.
+            - trash_id: b2f2af430f73f3ad1f9948f33e0f0cf8 # [Release Groups] HQ
+              assign_scores_to:
+                - name: UHD Bluray + WEB
             # Hard-block DV without HDR fallback
             - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76 # [HDR Formats] DV (w/o HDR fallback)
             # Boost DV and HDR10+
@@ -232,6 +241,20 @@ data:
           skip:
             - 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
           add:
+            # Release-group tier scoring for Remux / HD Bluray / WEB. Not
+            # default-synced (natural include is only Base Profile), so
+            # explicitly assigned to our profile. The profile template only
+            # ships WEB tier scoring in its formatItems; this group adds
+            # Remux Tier 01/02 (+1900/+1850) and HD Bluray Tier 01/02
+            # (+1800/+1750) so the Bluray-2160p Remux / Bluray-1080p Remux /
+            # Bluray-1080p qualities enabled above actually get release-group
+            # quality scoring (FraMeSToR-tier groups outscore generic ones).
+            # Note: Sonarr's HQ group has no UHD Bluray release-group CFs;
+            # TRaSH does not maintain a UHD Bluray release-group tier list
+            # for Sonarr (4K TV remuxes are too rare a corpus).
+            - trash_id: b4a4353e3b3e6789dbef07677ff23686 # [Release Groups] HQ
+              assign_scores_to:
+                - name: WEB-2160p
             # Hard-block DV without HDR fallback
             - trash_id: d776a1ea912a117d66d83b880ff2055d # [HDR Formats] DV (w/o HDR fallback)
             # Boost DV and HDR10+

--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -89,12 +89,17 @@ data:
             # Miscellaneous optional formats
             # DV (Disk) intentionally omitted: prefer P8 hybrid remuxes over
             # non-hybrid P7 FEL for the LG C2 + Shield + Wholphin path.
-            # x266 is the only CF in this group with a real (-10000) default
-            # score; the rest (HFR, MULTi, VC-1, VP9, x264, x265) have no
-            # default score and would only clutter the Radarr UI.
+            # x266 blocked (-10000). INTERNAL boosted (+10) as a small quality
+            # signal for P2P internal releases. Other CFs in this group (HFR,
+            # MULTi, VC-1, VP9, x264, x265) have no default score and would
+            # only clutter the Radarr UI.
             - trash_id: 9337080378236ce4c0b183e35790d2a7 # [Optional] Miscellaneous
               select:
                 - 390455c22a9cac81a738f6cbad705c3c # x266
+                - 182fa1c42a2468f8488e6dcf75a81b81 # INTERNAL
+            # Accessibility: hard-block releases tagged with sign-language
+            # interpreters or audio-description overlays (WiTH AD/ASL/BSL/BASL).
+            - trash_id: bc3c13e52f2971319bc1748ffa3d1078 # [Optional] Accessibility
           # Synced by default: Audio Formats, HDR, Streaming Services General,
           # Unwanted Formats (Bad Dual Groups, B&W, No-RlsGroup, Obfuscated,
           # Retags, Scene are auto-synced via Unwanted Formats group).
@@ -107,6 +112,15 @@ data:
             assign_scores_to:
               - name: UHD Bluray + WEB
                 score: 500
+
+          # Boost IMAX Enhanced above default (+800) so it pulls ahead of
+          # standard IMAX when both are available. The LG C2 supports IMAX
+          # Enhanced (DTS:X / wider color), so a slight preference is warranted.
+          - trash_ids:
+              - 9f6cbff8cfe4ebbc1bde14c7b7bec0de # IMAX Enhanced
+            assign_scores_to:
+              - name: UHD Bluray + WEB
+                score: 1000
 
       radarr_ru:
         base_url: http://radarr-ru.media.svc.cluster.local:7878
@@ -268,12 +282,30 @@ data:
             # Miscellaneous optional formats
             # DV (Disk) intentionally omitted: prefer P8 hybrid remuxes over
             # non-hybrid P7 FEL for the LG C2 + Shield + Wholphin path.
-            # x266 is the only CF in this group with a real (-10000) default
-            # score; the rest (HFR, MULTi, VC-1, VP9, x264, x265) have no
+            # x266 blocked (-10000). INTERNAL boosted (+10) as a small quality
+            # signal for P2P internal releases. Other CFs in this group (HFR,
+            # MULTi, VC-1, VP9, x264, x265, Multi/Single-Episode) have no
             # default score and would only clutter the Sonarr UI.
             - trash_id: f4a0410a1df109a66d6e47dcadcce014 # [Optional] Miscellaneous
               select:
                 - 041d90b435ebd773271cea047a457a6a # x266
+                - 5ab46ff851b76c337e13e81a4353875f # INTERNAL
+            # Accessibility: hard-block releases tagged with sign-language
+            # interpreters or audio-description overlays (WiTH AD/ASL/BSL/BASL).
+            - trash_id: bad5bc85573a0134e1e1987c46f67e98 # [Optional] Accessibility
+            # Season Packs: small bias (+10) toward full-season releases over
+            # per-episode batches for cleaner library organization.
+            - trash_id: d920fd959d220306888f40b6f38e1578 # [Optional] Season Packs
+              assign_scores_to:
+                - name: WEB-2160p
+            # Series Versions: bias toward remastered TV (e.g. Star Trek TNG,
+            # Buffy, X-Files restorations). Hybrid is handled by the explicit
+            # override below, so only Remaster is selected here.
+            - trash_id: a4a95b9f7bdf10dcb005e765155e4d24 # [Optional] Series Versions
+              assign_scores_to:
+                - name: WEB-2160p
+              select:
+                - b735f09d3c025cbb7d75a5d38325b73b # Remaster
             # Audio Formats: NOT auto-synced for Sonarr (unlike Radarr).
             # Applied to both the main UHD profile and the anime profile so
             # both get proper audio scoring without inline duplication.

--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -53,8 +53,6 @@ data:
 
         custom_format_groups:
           add:
-            # Required: penalizes x265 without HDR/DV
-            - trash_id: ff204bbcecdd487d1cefcefdbf0c278d # [Required] Golden Rule UHD
             # Hard-block DV without HDR fallback
             - trash_id: 7fc2751eef7e6bdc70b74136e5e35c76 # [HDR Formats] DV (w/o HDR fallback)
             # Boost DV and HDR10+
@@ -234,8 +232,6 @@ data:
           skip:
             - 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
           add:
-            # Required: penalizes x265 without HDR/DV
-            - trash_id: e3f37512790f00d0e89e54fe5e790d1c # [Required] Golden Rule UHD
             # Hard-block DV without HDR fallback
             - trash_id: d776a1ea912a117d66d83b880ff2055d # [HDR Formats] DV (w/o HDR fallback)
             # Boost DV and HDR10+

--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -80,23 +80,29 @@ data:
                 - 9c38ebb7384dada637be8899efa68e6f # SDR
                 - 25c12f78430a3a23413652cbd1d48d77 # SDR (no WEBDL)
             # Miscellaneous optional formats
+            # DV (Disk) intentionally omitted: prefer P8 hybrid remuxes over
+            # non-hybrid P7 FEL for the LG C2 + Shield + Wholphin path.
             - trash_id: 9337080378236ce4c0b183e35790d2a7 # [Optional] Miscellaneous
               select:
-                - b6832f586342ef70d9c128d40c07b872 # Bad Dual Groups
-                - cc444569854e9de0b084ab2b8b1532b2 # Black and White Editions
-                - f700d29429c023a5734505e77daeaea7 # DV (Disk)
                 - 73613461ac2cea99d52c4cd6e177ab82 # HFR
                 - 4b900e171accbfb172729b63323ea8ca # Multi
-                - ae9b7c9ebde1f3bd336a8cbd1ec4c5e5 # No-RlsGroup
-                - 7357cf5161efbf8c4d5d0c30b4815ee2 # Obfuscated
-                - 5c44f52a8714fdd79bb4d98e2673be1f # Retags
-                - f537cf427b64c38c8e36298f657e4828 # Scene
                 - 11cd1db7165d6a7ad9a83bc97b8b1060 # VC-1
                 - ae4cfaa9283a4f2150ac3da08e388723 # VP9
                 - 2899d84dc9372de3408e6d8cc18e9666 # x264
                 - 9170d55c319f4fe40da8711ba9d8050d # x265
                 - 390455c22a9cac81a738f6cbad705c3c # x266
-          # Synced by default: Audio Formats, HDR, Streaming Services General
+          # Synced by default: Audio Formats, HDR, Streaming Services General,
+          # Unwanted Formats (Bad Dual Groups, B&W, No-RlsGroup, Obfuscated,
+          # Retags, Scene are auto-synced via Unwanted Formats group).
+
+        custom_formats:
+          # Boost Hybrid above default (+100) so P8 hybrid remuxes reliably
+          # win over non-hybrid P7 FEL remuxes of equivalent tier.
+          - trash_ids:
+              - 0f12c086e289cf966fa5948eac571f44 # Hybrid
+            assign_scores_to:
+              - name: UHD Bluray + WEB
+                score: 500
 
       radarr_ru:
         base_url: http://radarr-ru.media.svc.cluster.local:7878
@@ -237,24 +243,32 @@ data:
                 - 2016d1676f5ee13a5b7257ff86ac9a93 # SDR
                 - 83304f261cf516bb208c18c54c0adf97 # SDR (no WEBDL)
             # Miscellaneous optional formats
+            # DV (Disk) intentionally omitted: prefer P8 hybrid remuxes over
+            # non-hybrid P7 FEL for the LG C2 + Shield + Wholphin path.
             - trash_id: f4a0410a1df109a66d6e47dcadcce014 # [Optional] Miscellaneous
               select:
-                - 32b367365729d530ca1c124a0b180c64 # Bad Dual Groups
-                - ef4963043b0987f8485bc9106f16db38 # DV (Disk)
                 - 1bd69272e23c5e6c5b1d6c8a36fce95e # HFR
                 - 7ba05c6e0e14e793538174c679126996 # MULTi
-                - 82d40da2bc6923f41e14394075dd4b03 # No-RlsGroup
-                - e1a997ddb54e3ecbfe06341ad323c458 # Obfuscated
-                - 06d66ab109d4d2eddb2794d21526d140 # Retags
-                - 1b3994c551cbb92a2c781af061f4ab44 # Scene
                 - 7470a681e6205243983c4410ee4c920f # VC-1
                 - 90501962793d580d011511155c97e4e5 # VP9
                 - cddfb4e32db826151d97352b8e37c648 # x264
                 - c9eafd50846d299b862ca9bb6ea91950 # x265
                 - 041d90b435ebd773271cea047a457a6a # x266
-          # Synced by default: Audio Formats, HDR, Streaming Services General
+          # Synced by default: Audio Formats, HDR, Streaming Services General,
+          # Unwanted Formats (Bad Dual Groups, No-RlsGroup, Obfuscated,
+          # Retags, Scene are auto-synced via Unwanted Formats group).
 
         custom_formats:
+          # Boost Hybrid above default (+100) so P8 hybrid remuxes reliably
+          # win over non-hybrid P7 FEL remuxes of equivalent tier. The Sonarr
+          # Hybrid CF isn't in any group that auto-syncs to WEB-2160p, so
+          # this both opts it in and sets the local score.
+          - trash_ids:
+              - 3a4127d8aa781b44120d907f2cd62627 # Hybrid
+            assign_scores_to:
+              - name: WEB-2160p
+                score: 500
+
           # Override anime template defaults
           - trash_ids:
               - b2550eb333d27b75833e25b8c2557b38 # 10bit

--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -82,14 +82,11 @@ data:
             # Miscellaneous optional formats
             # DV (Disk) intentionally omitted: prefer P8 hybrid remuxes over
             # non-hybrid P7 FEL for the LG C2 + Shield + Wholphin path.
+            # x266 is the only CF in this group with a real (-10000) default
+            # score; the rest (HFR, MULTi, VC-1, VP9, x264, x265) have no
+            # default score and would only clutter the Radarr UI.
             - trash_id: 9337080378236ce4c0b183e35790d2a7 # [Optional] Miscellaneous
               select:
-                - 73613461ac2cea99d52c4cd6e177ab82 # HFR
-                - 4b900e171accbfb172729b63323ea8ca # Multi
-                - 11cd1db7165d6a7ad9a83bc97b8b1060 # VC-1
-                - ae4cfaa9283a4f2150ac3da08e388723 # VP9
-                - 2899d84dc9372de3408e6d8cc18e9666 # x264
-                - 9170d55c319f4fe40da8711ba9d8050d # x265
                 - 390455c22a9cac81a738f6cbad705c3c # x266
           # Synced by default: Audio Formats, HDR, Streaming Services General,
           # Unwanted Formats (Bad Dual Groups, B&W, No-RlsGroup, Obfuscated,
@@ -229,6 +226,13 @@ data:
                   - HDTV-720p
 
         custom_format_groups:
+          # Opt out of [Optional] Language Profiles. It auto-syncs by default
+          # for Sonarr and brings in CFs like "German +10000" / "Not English
+          # -10000". Profile language is "Original" which already gates the
+          # release language at the profile level, but skipping keeps the
+          # scoring clean and avoids surprise CFs appearing in Sonarr.
+          skip:
+            - 74aff4168620ed49dcc67e92b2c2a5b4 # [Optional] Language Profiles
           add:
             # Required: penalizes x265 without HDR/DV
             - trash_id: e3f37512790f00d0e89e54fe5e790d1c # [Required] Golden Rule UHD
@@ -245,18 +249,23 @@ data:
             # Miscellaneous optional formats
             # DV (Disk) intentionally omitted: prefer P8 hybrid remuxes over
             # non-hybrid P7 FEL for the LG C2 + Shield + Wholphin path.
+            # x266 is the only CF in this group with a real (-10000) default
+            # score; the rest (HFR, MULTi, VC-1, VP9, x264, x265) have no
+            # default score and would only clutter the Sonarr UI.
             - trash_id: f4a0410a1df109a66d6e47dcadcce014 # [Optional] Miscellaneous
               select:
-                - 1bd69272e23c5e6c5b1d6c8a36fce95e # HFR
-                - 7ba05c6e0e14e793538174c679126996 # MULTi
-                - 7470a681e6205243983c4410ee4c920f # VC-1
-                - 90501962793d580d011511155c97e4e5 # VP9
-                - cddfb4e32db826151d97352b8e37c648 # x264
-                - c9eafd50846d299b862ca9bb6ea91950 # x265
                 - 041d90b435ebd773271cea047a457a6a # x266
-          # Synced by default: Audio Formats, HDR, Streaming Services General,
-          # Unwanted Formats (Bad Dual Groups, No-RlsGroup, Obfuscated,
-          # Retags, Scene are auto-synced via Unwanted Formats group).
+            # Audio Formats: NOT auto-synced for Sonarr (unlike Radarr).
+            # Applied to both the main UHD profile and the anime profile so
+            # both get proper audio scoring without inline duplication.
+            - trash_id: e9a1944a254e6f8a9da63083f7ae15cb # [Audio] Audio Formats
+              assign_scores_to:
+                - name: WEB-2160p
+                - name: Remux-1080p - Anime
+          # Synced by default: HDR, Streaming Services General, HD/UHD Streaming
+          # Boost, Unwanted Formats (Bad Dual Groups, No-RlsGroup, Obfuscated,
+          # Retags, Scene are auto-synced via Unwanted Formats group). Language
+          # Profiles auto-syncs by default but is explicitly skipped above.
 
         custom_formats:
           # Boost Hybrid above default (+100) so P8 hybrid remuxes reliably
@@ -281,25 +290,6 @@ data:
             assign_scores_to:
               - name: Remux-1080p - Anime
                 score: 0
-
-          # Audio formats for the anime profile (groups only target WEB-2160p)
-          - trash_ids:
-              - 0d7824bb924701997f874e7ff7d4844a # TrueHD ATMOS
-              - 9d00418ba386a083fbf4d58235fc37ef # DTS X
-              - b6fbafa7942952a13e17e2b1152b539a # ATMOS (undefined)
-              - 4232a509ce60c4e208d13825b7c06264 # DD+ ATMOS
-              - 1808e4b9cee74e064dfae3f1db99dbfe # TrueHD
-              - c429417a57ea8c41d57e6990a8b0033f # DTS-HD MA
-              - 851bd64e04c9374c51102be3dd9ae4cc # FLAC
-              - 30f70576671ca933adbdcfc736a69718 # PCM
-              - cfa5fbd8f02a86fc55d8d223d06a5e1f # DTS-HD HRA
-              - 63487786a8b01b7f20dd2bc90dd4a477 # DD+
-              - c1a25cd67b5d2e08287c957b1eb903ec # DTS-ES
-              - 5964f2a8b3be407d083498e4459d05d0 # DTS
-              - a50b8a0c62274a7c38b09a9619ba9d86 # AAC
-              - dbe00161b08a25ac6154c55f95e6318d # DD
-            assign_scores_to:
-              - name: Remux-1080p - Anime
 
           # Unwanted formats for the anime profile
           - trash_ids:


### PR DESCRIPTION
## Why

Reshape Recyclarr scoring on `radarr_main` + `sonarr_main` so P8 hybrid remuxes reliably win over non-hybrid P7 FEL remuxes of equivalent tier. Targets the LG C2 + Shield + Wholphin playback path — Wholphin can't render FEL anyway (it ignores the EL and plays as P8), so we'd rather grab a clean P8 hybrid in the first place.

RU instances are 1080p WEB only and untouched.

## Changes

| Change | Radarr main | Sonarr main |
|---|---|---|
| Remove `DV (Disk)` (+101) from Optional Misc select | ✅ | ✅ |
| Add `Hybrid` CF override @ **+500** (default is +100) | ✅ | ✅ (also opts the CF in — not auto-synced to WEB-2160p) |
| Drop dead selects (moved to Unwanted Formats, auto-syncs) | Bad Dual Groups, B&W, No-RlsGroup, Obfuscated, Retags, Scene | Bad Dual Groups, No-RlsGroup, Obfuscated, Retags, Scene |

## Scoring math (like-for-like top-tier remux)

| | P7 non-hybrid | P8 hybrid |
|---|---|---|
| DV Boost | +1000 | +1000 |
| HDR | +500 | +500 |
| DV (Disk) | ~~+101~~ removed | — |
| UHD Bluray Tier 01 | +1700 | +1700 |
| TrueHD Atmos | +5000 | +5000 |
| Hybrid | — | **+500** |
| **Total** | ~8200 | ~8700 |

P8 hybrid wins by 500 — comfortable, survives one-tier release-group deltas, but a low-tier hybrid still loses to a top-tier non-hybrid (intentional).

## Cleanup

`delete_old_custom_formats: true` will prune the now-orphaned `DV (Disk)` CF on next sync.

## Verified

- YAML parses inside the ConfigMap
- Prettier: no formatting changes
- Recyclarr v8 `custom_format_groups` auto-sync behavior confirmed against [recyclarr.dev docs](https://recyclarr.dev/wiki/yaml/config-reference/custom-formats/)
