### PR TITLE
feat: NVMe-backed qBittorrent incomplete cache (SN850X 2TB)

### DIFF
--- a/infrastructure/base-configs/templates/incomplete-storage/pv.yaml
+++ b/infrastructure/base-configs/templates/incomplete-storage/pv.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: qbittorrent-incomplete-pv
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
+spec:
+  capacity:
+    storage: 1300Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    server: {{ .Values.global.network.nfs.server }}
+    path: /mnt/nvme-cache/incomplete
+  mountOptions:
+    - nfsvers=4.1
+    - noatime
+    - hard
+    - rsize=1048576
+    - wsize=1048576

--- a/infrastructure/base-configs/templates/incomplete-storage/pvc.yaml
+++ b/infrastructure/base-configs/templates/incomplete-storage/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qbittorrent-incomplete-pvc
+  namespace: media
+  annotations:
+    argocd.argoproj.io/sync-options: Delete=false
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: qbittorrent-incomplete-pv
+  resources:
+    requests:
+      storage: 1300Gi

--- a/services/media/qbittorrent-ru/values.yaml
+++ b/services/media/qbittorrent-ru/values.yaml
@@ -9,3 +9,11 @@ service:
         port: 56882
       bittorrent-udp:
         port: 56882
+
+persistence:
+  incomplete:
+    advancedMounts:
+      main:
+        main:
+          - path: /downloads/incomplete
+            subPath: qbittorrent-ru

--- a/services/media/qbittorrent/values.yaml
+++ b/services/media/qbittorrent/values.yaml
@@ -58,3 +58,12 @@ service:
 persistence:
   media:
     enabled: true
+  incomplete:
+    enabled: true
+    type: persistentVolumeClaim
+    existingClaim: qbittorrent-incomplete-pvc
+    advancedMounts:
+      main:
+        main:
+          - path: /downloads/incomplete
+            subPath: qbittorrent


### PR DESCRIPTION
Adds a new static NFS PV + PVC backed by `nvme-cache/incomplete` on the
TrueNAS VM (sourced from the new WD Black SN850X 2 TB passed through to
VM 100), and wires both qBittorrent instances to mount it at
`/downloads/incomplete` under per-instance subPaths:

- `qbittorrent`    -> `/mnt/nvme-cache/incomplete/qbittorrent`
- `qbittorrent-ru` -> `/mnt/nvme-cache/incomplete/qbittorrent-ru`

Companion infra changes (PVE `hostpci2` on VM 100; TrueNAS partitioning,
pool creation, L2ARC cache vdev add, NFS share) are operator-applied and
not represented in this repo.

**Post-merge manual step:** in each qBittorrent WebUI, Tools -> Options
-> Downloads -> tick "Keep incomplete torrents in" and set the path to
`/downloads/incomplete`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>