### PR TITLE
feat(nfs): enable nconnect=8 on TrueNAS-backed PVs

### DIFF
--- a/infrastructure/base-configs/templates/incomplete-storage/pv.yaml
+++ b/infrastructure/base-configs/templates/incomplete-storage/pv.yaml
@@ -20,3 +20,4 @@ spec:
     - hard
     - rsize=1048576
     - wsize=1048576
+    - nconnect=8

--- a/infrastructure/base-configs/templates/media-storage/pv.yaml
+++ b/infrastructure/base-configs/templates/media-storage/pv.yaml
@@ -19,3 +19,4 @@ spec:
     - hard
     - rsize=1048576
     - wsize=1048576
+    - nconnect=8


### PR DESCRIPTION
## Why

Cross-export torrent moves (NVMe incomplete → HDD media pool) tank global download speed because the pod-side NFS client runs both legs of the copy over a **single TCP connection** to TrueNAS, in addition to the live peer traffic. Single-stream NFSv4.1 commonly tops out around 1.5–3 Gbps regardless of underlying disk speed.

`nconnect=N` opens N parallel TCP connections per (server, protocol) pair and round-robins RPCs across them. Stable in the Linux kernel since 5.3.

## What

Add `nconnect=8` to mountOptions on:
- `qbittorrent-incomplete-pv` (new NVMe incomplete cache PV)
- `media-library-pv` (existing media library PV)

Both PVs point at `10.9.8.30`. The kernel NFS client maintains one transport pool per (server, protocol) pair: the **first** mount to a given server decides nconnect; later mounts ignore their own value. Setting it on both ensures we get parallelism regardless of which mounts first.

## Expected impact

- Faster completion of cross-filesystem moves (TrueNAS NVMe → HDD), shortening the download-speed dip during a move.
- Modest extra socket buffer / CPU usage on the pod and on TrueNAS (negligible at our scale).
- Does **not** address HDD write-side bottleneck — depth of the dip is reduced, not eliminated.

## Rollout

PV mountOptions are only consulted on fresh mounts; existing pods keep their old single-connection mount until restarted. After merge:

1. Restart consumers of these PVs so kubelet re-mounts (qbittorrent, qbittorrent-ru, *arrs, jellyfin, etc.).
2. Verify: `cat /proc/self/mountstats | grep -A2 10.9.8.30` inside a pod should show `xprt:` line per connection (8 of them).

## Risk

Low. Worst case: revert PR, restart pods.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>