### PR TITLE
Rebalance scheduling off the control-plane node and pin qBittorrent to workers

### DIFF
--- a/infrastructure/controllers/authentik/values.yaml
+++ b/infrastructure/controllers/authentik/values.yaml
@@ -49,6 +49,9 @@ authentik:
   disable_update_check: true
   disable_startup_analytics: true
 server:
+  resources:
+    requests:
+      memory: 1Gi
   metrics:
     enabled: true
     serviceMonitor:

--- a/services/home-automation/home-assistant/values.yaml
+++ b/services/home-automation/home-assistant/values.yaml
@@ -5,6 +5,9 @@ controllers:
         image:
           repository: ghcr.io/home-assistant/home-assistant
           tag: 2026.6.0@sha256:60af7f5d4d13368c86c73611e4a3ce32534eb573bce09f26b98d647291c3df8c
+        resources:
+          requests:
+            memory: 512Mi
         env:
           PUID: null
           PGID: null

--- a/services/media/qbittorrent/values.yaml
+++ b/services/media/qbittorrent/values.yaml
@@ -1,5 +1,8 @@
 controllers:
   main:
+    pod:
+      nodeSelector:
+        node-role.kubernetes.io/worker: "true"
     initContainers:
       clean-stale-locks:
         image:

--- a/services/operations/karakeep/values.yaml
+++ b/services/operations/karakeep/values.yaml
@@ -5,6 +5,9 @@ controllers:
         image:
           repository: ghcr.io/karakeep-app/karakeep
           tag: 0.32.0@sha256:64d6a9bbf2d37b5c808cf06b5d87f1f1c7846fdd3844724145a9741aeb06fd31
+        resources:
+          requests:
+            memory: 512Mi
         env:
           DATA_DIR: "/data"
           NEXTAUTH_URL: "https://karakeep.starktastic.net"

--- a/services/operations/kube-prometheus-stack/values.yaml
+++ b/services/operations/kube-prometheus-stack/values.yaml
@@ -102,6 +102,9 @@ alertmanager:
 # -----------------------------------------------------------------------------
 grafana:
   enabled: true
+  resources:
+    requests:
+      memory: 640Mi
   admin:
     existingSecret: grafana-admin-secret
     userKey: admin-user

--- a/services/operations/paperless-ngx/values.yaml
+++ b/services/operations/paperless-ngx/values.yaml
@@ -5,6 +5,9 @@ controllers:
         image:
           repository: ghcr.io/paperless-ngx/paperless-ngx
           tag: 2.20.15@sha256:6c86cad803970ea782683a8e80e7403444c5bf3cf70de63b4d3c8e87500db92f
+        resources:
+          requests:
+            memory: 640Mi
         env:
           # Database
           PAPERLESS_DBHOST: "postgres-postgresql.databases.svc.cluster.local"

--- a/services/operations/stirling-pdf/values.yaml
+++ b/services/operations/stirling-pdf/values.yaml
@@ -5,6 +5,9 @@ controllers:
         image:
           repository: stirlingtools/stirling-pdf
           tag: latest@sha256:b75b5ae2fcb75948f468718ed4c0bd499a8cafc9daf7f90f4c1e0e5a6acf9df8
+        resources:
+          requests:
+            memory: 768Mi
         env:
           SECURITY_ENABLELOGIN: "false"
         probes:


### PR DESCRIPTION
## Problem

`kube-master-01` (the cluster's smallest node: 4 vCPU / 16 GiB, and the control-plane) was running ~80 pods at **84% memory**, while `kube-worker-01` sat at **38%**. Because almost no workloads set memory `requests`, the scheduler saw the master as nearly empty (1.25 GiB requested of 16) and kept scheduling onto it.

The heavy memory consumers on the master were general infra — authentik, stirling-pdf, grafana, paperless, home-assistant, karakeep — **not** media. The media pods that land there are featherweights, and the genuinely heavy media (Jellyfin/Immich) are already pinned to the GPU workers via `gpu.intel.com/i915` requests.

## Approach

Rather than tainting the master (which would sacrifice a node of capacity and worsen single-node-failure tolerance on a 3-node cluster), this fixes the **scheduling imbalance** at its root:

**Add memory `requests` to the top consumers** so the scheduler accounts for real usage and spreads load onto the under-used worker:

| Service | request |
|---|---|
| authentik server | 1Gi |
| stirling-pdf | 768Mi |
| grafana | 640Mi |
| paperless-ngx | 640Mi |
| home-assistant | 512Mi |
| karakeep | 512Mi |

**Pin qBittorrent to workers** (`qbittorrent`, and `qbittorrent-ru` via the base override) mirroring `subgen`, so the two unpinned, GPU-less heavy media services can't drift onto the master.

## Notes

- No node taint, no VM resizing — master stays schedulable to preserve capacity and failure tolerance.
- Memory requests only (CPU is ~single-digit % cluster-wide); no limits (avoids OOM-kill risk).
- Rebalancing takes effect as pods reschedule (next Argo sync / rollout). A one-time `kubectl rollout restart` can nudge it immediately.
- ArgoCD's own controller request is handled in a companion ansible PR (it's installed via the bootstrap role, not this repo).