### PR TITLE
fix(homepage): branding, calendar & widget fixes (round 2)

### DIFF
--- a/services/operations/homepage-admin/manifests/templates/configmap.yaml
+++ b/services/operations/homepage-admin/manifests/templates/configmap.yaml
@@ -9,34 +9,32 @@ data:
       url: https://10.9.9.20:8006
       token: {{ "{{" }}HOMEPAGE_VAR_PROXMOX_USER{{ "}}" }}
       secret: {{ "{{" }}HOMEPAGE_VAR_PROXMOX_PASS{{ "}}" }}
-  logo.svg: |
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 56">
+  favicon.svg: |
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
       <defs>
-        <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-          <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-          <feFlood flood-color="#DC2626" flood-opacity="0.6" result="color"/>
+        <filter id="glow">
+          <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+          <feFlood flood-color="#DC2626" flood-opacity="0.5" result="color"/>
           <feComposite in="color" in2="blur" operator="in" result="shadow"/>
           <feMerge>
             <feMergeNode in="shadow"/>
             <feMergeNode in="SourceGraphic"/>
           </feMerge>
         </filter>
-        <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
-          <feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#000" flood-opacity="0.5"/>
-        </filter>
       </defs>
-      <text x="0" y="34" font-family="Arial, Helvetica, sans-serif"
-            font-size="36" font-weight="800" letter-spacing="2" filter="url(#shadow)">
-        <tspan fill="#F1F5F9">STARK</tspan><tspan fill="#DC2626" filter="url(#glow)">TASTIC</tspan>
-      </text>
-      <text x="1" y="52" font-family="Arial, Helvetica, sans-serif"
-            font-size="13" font-weight="600" letter-spacing="6" fill="#94A3B8">
-        SERVICES
+      <rect width="48" height="48" rx="10" fill="#0F0F1A"/>
+      <text x="50%" y="34" text-anchor="middle" font-family="Arial, Helvetica, sans-serif"
+            font-size="26" font-weight="800" letter-spacing="1">
+        <tspan fill="#F1F5F9">S</tspan><tspan fill="#DC2626" filter="url(#glow)">T</tspan>
       </text>
     </svg>
   docker.yaml: ""
   custom.js: ""
-  custom.css: ""
+  custom.css: |
+    /* Hide the redundant card title above the calendar widget */
+    li.service[data-name="Calendar"] .service-title {
+      display: none;
+    }
   kubernetes.yaml: |
     mode: cluster
   settings.yaml: |
@@ -48,7 +46,7 @@ data:
     disableCollapse: false
     disableIndexing: true
     iconStyle: theme
-    favicon: /icons/logo.svg
+    favicon: /icons/favicon.svg
     quicklaunch:
       searchDescriptions: true
       hideInternetSearch: false
@@ -72,6 +70,7 @@ data:
         style: row
         columns: 1
         icon: mdi-calendar-month
+        header: false
       Streaming:
         tab: Home
         style: row
@@ -162,10 +161,7 @@ data:
         icon: postgres.png
   widgets.yaml: |
     - logo:
-        icon: /icons/logo.svg
-    - greeting:
-        text_size: xl
-        text: Welcome to Starktastic
+        icon: /icons/favicon.svg
     - kubernetes:
         cluster:
           show: true
@@ -204,36 +200,26 @@ data:
               maxEvents: 15
               showTime: true
               integrations:
-                - type: sonarr
-                  service_group: Movies & TV
-                  service_name: Sonarr
-                  color: "#3B82F6"
-                  params:
-                    unmonitored: true
-                - type: sonarr
-                  service_group: Movies & TV
-                  service_name: Sonarr RU
-                  color: "#60A5FA"
-                  params:
-                    unmonitored: true
-                - type: radarr
-                  service_group: Movies & TV
-                  service_name: Radarr
-                  color: "#DC2626"
-                  params:
-                    unmonitored: true
-                - type: radarr
-                  service_group: Movies & TV
-                  service_name: Radarr RU
-                  color: "#F87171"
-                  params:
-                    unmonitored: true
-                - type: lidarr
-                  service_group: Music & Books
-                  service_name: Lidarr
-                  color: "#22C55E"
-                  params:
-                    unmonitored: true
+                - type: ical
+                  url: http://sonarr.media.svc.cluster.local:8989/feed/v3/calendar/Sonarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_SONARR_KEY{{ "}}" }}
+                  name: Sonarr
+                  color: blue
+                - type: ical
+                  url: http://sonarr-ru.media.svc.cluster.local:8989/feed/v3/calendar/Sonarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_SONARR_RU_KEY{{ "}}" }}
+                  name: Sonarr RU
+                  color: sky
+                - type: ical
+                  url: http://radarr.media.svc.cluster.local:7878/feed/v3/calendar/Radarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_RADARR_KEY{{ "}}" }}
+                  name: Radarr
+                  color: red
+                - type: ical
+                  url: http://radarr-ru.media.svc.cluster.local:7878/feed/v3/calendar/Radarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_RADARR_RU_KEY{{ "}}" }}
+                  name: Radarr RU
+                  color: rose
+                - type: ical
+                  url: http://lidarr.media.svc.cluster.local:8686/feed/v1/calendar/Lidarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_LIDARR_KEY{{ "}}" }}
+                  name: Lidarr
+                  color: green
     - Streaming:
         - Jellyfin:
             icon: jellyfin.png
@@ -282,7 +268,7 @@ data:
             icon: calibre-web.png
             href: https://books.benplus.app
             description: E-book library
-            siteMonitor: http://calibre-web.media.svc.cluster.local:8083
+            siteMonitor: http://calibre-web.media.svc.cluster.local:8083/opds
             widget:
               type: calibreweb
               url: http://calibre-web.media.svc.cluster.local:8083
@@ -522,7 +508,7 @@ data:
             icon: grafana.png
             href: https://grafana.internal.starktastic.net
             description: Dashboards & Alerting
-            siteMonitor: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80
+            siteMonitor: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80/api/health
             widget:
               type: grafana
               alerts: alertmanager
@@ -648,6 +634,7 @@ data:
               headers:
                 Authorization: Bearer {{ "{{" }}HOMEPAGE_VAR_GITHUB_TOKEN{{ "}}" }}
                 X-GitHub-Api-Version: "2022-11-28"
+                User-Agent: Homepage-Dashboard
               mappings:
                 name: title
                 label: user.login
@@ -665,6 +652,7 @@ data:
               headers:
                 Authorization: Bearer {{ "{{" }}HOMEPAGE_VAR_GITHUB_TOKEN{{ "}}" }}
                 X-GitHub-Api-Version: "2022-11-28"
+                User-Agent: Homepage-Dashboard
               mappings:
                 name: title
                 label: user.login
@@ -682,6 +670,7 @@ data:
               headers:
                 Authorization: Bearer {{ "{{" }}HOMEPAGE_VAR_GITHUB_TOKEN{{ "}}" }}
                 X-GitHub-Api-Version: "2022-11-28"
+                User-Agent: Homepage-Dashboard
               mappings:
                 name: title
                 label: user.login
@@ -699,6 +688,7 @@ data:
               headers:
                 Authorization: Bearer {{ "{{" }}HOMEPAGE_VAR_GITHUB_TOKEN{{ "}}" }}
                 X-GitHub-Api-Version: "2022-11-28"
+                User-Agent: Homepage-Dashboard
               mappings:
                 name: title
                 label: user.login

--- a/services/operations/homepage-admin/values.yaml
+++ b/services/operations/homepage-admin/values.yaml
@@ -88,11 +88,14 @@ persistence:
       - path: /app/config/custom.js
         subPath: custom.js
         readOnly: true
+      - path: /app/config/custom.css
+        subPath: custom.css
+        readOnly: true
       - path: /app/config/docker.yaml
         subPath: docker.yaml
         readOnly: true
-      - path: /app/public/icons/logo.svg
-        subPath: logo.svg
+      - path: /app/public/icons/favicon.svg
+        subPath: favicon.svg
         readOnly: true
   logs:
     enabled: true

--- a/services/operations/homepage/manifests/templates/configmap.yaml
+++ b/services/operations/homepage/manifests/templates/configmap.yaml
@@ -4,34 +4,32 @@ metadata:
   name: homepage-config
   namespace: operations
 data:
-  logo.svg: |
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 56">
+  favicon.svg: |
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
       <defs>
-        <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-          <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-          <feFlood flood-color="#DC2626" flood-opacity="0.6" result="color"/>
+        <filter id="glow">
+          <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="blur"/>
+          <feFlood flood-color="#DC2626" flood-opacity="0.5" result="color"/>
           <feComposite in="color" in2="blur" operator="in" result="shadow"/>
           <feMerge>
             <feMergeNode in="shadow"/>
             <feMergeNode in="SourceGraphic"/>
           </feMerge>
         </filter>
-        <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
-          <feDropShadow dx="0" dy="1" stdDeviation="2" flood-color="#000" flood-opacity="0.5"/>
-        </filter>
       </defs>
-      <text x="0" y="34" font-family="Arial, Helvetica, sans-serif"
-            font-size="36" font-weight="800" letter-spacing="2" filter="url(#shadow)">
-        <tspan fill="#F1F5F9">STARK</tspan><tspan fill="#DC2626" filter="url(#glow)">TASTIC</tspan>
-      </text>
-      <text x="1" y="52" font-family="Arial, Helvetica, sans-serif"
-            font-size="13" font-weight="600" letter-spacing="6" fill="#94A3B8">
-        SERVICES
+      <rect width="48" height="48" rx="10" fill="#0F0F1A"/>
+      <text x="50%" y="34" text-anchor="middle" font-family="Arial, Helvetica, sans-serif"
+            font-size="26" font-weight="800" letter-spacing="1">
+        <tspan fill="#F1F5F9">S</tspan><tspan fill="#DC2626" filter="url(#glow)">T</tspan>
       </text>
     </svg>
   docker.yaml: ""
   custom.js: ""
-  custom.css: ""
+  custom.css: |
+    /* Hide the redundant card title above the calendar widget */
+    li.service[data-name="Calendar"] .service-title {
+      display: none;
+    }
   kubernetes.yaml: |
     mode: disabled
   settings.yaml: |
@@ -44,7 +42,7 @@ data:
     disableCollapse: false
     disableIndexing: true
     iconStyle: theme
-    favicon: /icons/logo.svg
+    favicon: /icons/favicon.svg
     quicklaunch:
       searchDescriptions: true
       hideInternetSearch: false
@@ -56,6 +54,7 @@ data:
         style: row
         columns: 1
         icon: mdi-calendar-month
+        header: false
       Streaming:
         style: row
         columns: 5
@@ -82,10 +81,7 @@ data:
         icon: mdi-tools
   widgets.yaml: |
     - logo:
-        icon: /icons/logo.svg
-    - greeting:
-        text_size: xl
-        text: Welcome to Starktastic
+        icon: /icons/favicon.svg
     - search:
         provider: custom
         url: https://search.starktastic.net/search?q=

--- a/services/operations/homepage/values.yaml
+++ b/services/operations/homepage/values.yaml
@@ -69,9 +69,12 @@ persistence:
       - path: /app/config/custom.js
         subPath: custom.js
         readOnly: true
+      - path: /app/config/custom.css
+        subPath: custom.css
+        readOnly: true
       - path: /app/config/docker.yaml
         subPath: docker.yaml
         readOnly: true
-      - path: /app/public/icons/logo.svg
-        subPath: logo.svg
+      - path: /app/public/icons/favicon.svg
+        subPath: favicon.svg
         readOnly: true


### PR DESCRIPTION
## Summary

Second round of fixes for both Homepage dashboards, addressing reported issues.

| # | Issue | Fix |
|---|-------|-----|
| 1 | Use `favicon.svg` for favicon **and** logo widget | Bundle the square `favicon.svg` (Authentik branding) as the ConfigMap asset, mount it, and point both `favicon:` and the logo widget at `/icons/favicon.svg` (both instances). Dropped the wordmark `logo.svg`. |
| 2 | Drop the greeting | Removed the `greeting` info widget (both instances). |
| 3 | Remove the "Calendar" title | `layout.Calendar.header: false` hides the group header; a targeted `custom.css` rule hides the redundant service-card title. Also mounted `custom.css` (it wasn't mounted before). |
| 4 | Admin calendar missing dots | Converted the admin calendar integrations from cross-tab `*arr` service references to self-contained iCal feeds (identical to the regular instance), so monthly-view dots render. The admin secret already has the five *arr keys. |
| 5 | Grafana & Calibre-Web red status (widgets work) | Their service roots return `http -> https` redirects that Homepage's proxy can't follow (HEAD → 500 → red). Repointed siteMonitor to non-redirecting endpoints: Grafana `/api/health` (200) and Calibre `/opds` (401). Both ≤ 403 → healthy. |
| 6 | GitHub PR widgets "API Error" | GitHub's API returns **403** without a `User-Agent` header. Added `User-Agent: Homepage-Dashboard` to all four customapi widgets. |

## Diagnosis notes

All root causes were verified live against the cluster:
- Grafana/Calibre siteMonitor returned `status: 500` from the pod's own `/api/siteMonitor` API (HEAD throws `ERR_FR_REDIRECTION_FAILURE` on the http→https redirect). The new endpoints return 200/401.
- A blank `User-Agent` to `api.github.com` returns 403; curl's default UA returns 200.

## Known follow-up (out of this repo)

**ArgoCD** widget still shows an API error: `argocd-server` returns a `307` redirect to `https`, which Homepage's http proxy can't follow. This requires `server.insecure: true` on the argo-cd Helm release, which is managed in **Ansible** (only the ApplicationSets live here).
