### PR TITLE
feat(homepage): add Dispatcharr tile and siteMonitor probe

### DIFF
--- a/services/operations/homepage-admin/manifests/templates/configmap.yaml
+++ b/services/operations/homepage-admin/manifests/templates/configmap.yaml
@@ -235,6 +235,11 @@ data:
               enableNowPlaying: true
               enableUser: true
               showEpisodeNumber: true
+        - Dispatcharr:
+            icon: dispatcharr.png
+            href: https://dispatcharr.internal.starktastic.net
+            description: Live TV & IPTV proxy
+            siteMonitor: http://dispatcharr.media.svc.cluster.local:9191
         - Immich:
             icon: immich.png
             href: https://photos.benplus.app

--- a/services/operations/homepage/manifests/templates/configmap.yaml
+++ b/services/operations/homepage/manifests/templates/configmap.yaml
@@ -140,6 +140,10 @@ data:
               enableNowPlaying: true
               enableUser: true
               showEpisodeNumber: true
+        - Dispatcharr:
+            icon: dispatcharr.png
+            href: https://dispatcharr.internal.starktastic.net
+            description: Live TV & IPTV proxy
         - Immich:
             icon: immich.png
             href: https://photos.benplus.app

--- a/services/operations/homepage/manifests/templates/configmap.yaml
+++ b/services/operations/homepage/manifests/templates/configmap.yaml
@@ -140,10 +140,6 @@ data:
               enableNowPlaying: true
               enableUser: true
               showEpisodeNumber: true
-        - Dispatcharr:
-            icon: dispatcharr.png
-            href: https://dispatcharr.internal.starktastic.net
-            description: Live TV & IPTV proxy
         - Immich:
             icon: immich.png
             href: https://photos.benplus.app


### PR DESCRIPTION
## Summary
- Add a **Dispatcharr** tile to the **Streaming** group on both Homepage instances (public + admin), placed right after Jellyfin since Dispatcharr is its Live TV source.
- Public tile: icon + href (`https://dispatcharr.internal.starktastic.net`) + description.
- Admin tile: same, plus `siteMonitor: http://dispatcharr.media.svc.cluster.local:9191` for a status dot.

## Notes
- siteMonitor targets the in-cluster service root `/`, verified to return HTTP 200 with no redirects (avoids the redirect→500 false-red issue).
- `dispatcharr.png` exists in dashboard-icons; ingress host confirmed against the live IngressRoute.

## Test Plan
- [x] Embedded `services.yaml` blocks parse as valid YAML
- [x] Ingress host matches deployed IngressRoute
- [ ] After sync: tiles render in both dashboards; admin status dot is green