### PR TITLE
feat(media): add samsung-tvplus FAST channel generator

### DIFF
--- a/services/media/samsung-tvplus/app.yaml
+++ b/services/media/samsung-tvplus/app.yaml
@@ -1,0 +1,3 @@
+name: samsung-tvplus
+namespace: media
+deployPhase: services

--- a/services/media/samsung-tvplus/values.yaml
+++ b/services/media/samsung-tvplus/values.yaml
@@ -1,0 +1,39 @@
+controllers:
+  main:
+    containers:
+      main:
+        image:
+          repository: docker.io/matthuisman/samsung-tvplus-for-channels
+          tag: latest@sha256:1693a960e581e059e9f3baaa89d7962cf1c8928a45fcc477861521e60023f4b5
+        env:
+          TZ: Asia/Jerusalem
+          PORT: "8080"
+          REGIONS: us
+          GROUPS: "Sports & Outdoors|Motor Sports"
+        probes:
+          liveness:
+            enabled: true
+            type: TCP
+            port: 8080
+          readiness:
+            enabled: true
+            type: TCP
+            port: 8080
+          startup:
+            enabled: true
+            type: TCP
+            port: 8080
+            spec:
+              failureThreshold: 30
+              periodSeconds: 5
+
+service:
+  main:
+    controller: main
+    ports:
+      http:
+        port: 8080
+
+persistence:
+  config:
+    enabled: false


### PR DESCRIPTION
## Summary
- Deploy **matthuisman/samsung-tvplus-for-channels** (official Samsung TV Plus API) as an internal-only service in `media`, so Dispatcharr can ingest **free, legally-licensed sports FAST channels** (NFL/MLB/NBA/NASCAR/PGA/UFC/FOX Sports/CBS Sports/beIN/Stadium/fubo, etc.).
- Filtered to US `Sports & Outdoors` + `Motor Sports` groups via the `GROUPS` env.
- Stateless (cache in `/tmp`, no PVC); ClusterIP only, no ingress.
- Listens on `8080` (`PORT` env, honored because the image sets `IS_DOCKER=1`).

## How to use (after sync)
In Dispatcharr → M3U & EPG Manager:
- **M3U**: `http://samsung-tvplus.media.svc.cluster.local:8080/playlist.m3u8?regions=us`
- **EPG**: `http://samsung-tvplus.media.svc.cluster.local:8080/epg.xml?regions=us`

The playlist `tvg-id` equals the EPG channel id, so EPG maps by id (no fuzzy/ML matching).

## Test Plan
- [x] `helm template` renders with full appset value stack (common.yaml + globals.yaml)
- [x] kubeconform: 3/3 resources valid
- [x] yamllint passes with repo config; prettier clean
- [ ] After ArgoCD sync: pod Running, `curl /playlist.m3u8?regions=us` returns sports channels