### PR TITLE
ci: P0 tooling hardening (Trivy scan, Renovate gates, pre-commit)

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -1,0 +1,82 @@
+name: Image vulnerability scan
+
+# Scans every container image referenced in services/** and infrastructure/**
+# values.yaml with Trivy and publishes CRITICAL/HIGH findings to the GitHub
+# Security tab. Advisory only — it never fails the build or blocks merges.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Trivy scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install yq
+        env:
+          # renovate: datasource=github-releases depName=mikefarah/yq
+          YQ_VERSION: 'v4.53.3'
+        run: |
+          curl -sSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Collect image references
+        id: collect
+        run: |
+          set -euo pipefail
+          : > images.txt
+          while IFS= read -r -d '' f; do
+            yq -N '.. | select(tag == "!!map" and has("repository") and has("tag")) | .repository + ":" + .tag' "$f" 2>/dev/null >> images.txt || true
+          done < <(find services infrastructure -type f -name 'values.yaml' -print0)
+          sort -u images.txt -o images.txt
+          COUNT=$(grep -cve '^[[:space:]]*$' images.txt || true)
+          echo "Found ${COUNT} unique images"
+          cat images.txt
+
+      - name: Install Trivy
+        env:
+          # renovate: datasource=github-releases depName=aquasecurity/trivy
+          TRIVY_VERSION: 'v0.71.2'
+        run: |
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+            | sh -s -- -b /usr/local/bin "${TRIVY_VERSION}"
+          trivy --version
+
+      - name: Scan images
+        run: |
+          set -uo pipefail
+          mkdir -p trivy-results
+          while IFS= read -r image; do
+            [ -z "$image" ] && continue
+            safe=$(printf '%s' "$image" | sed 's@[/:@]@_@g')
+            echo "::group::Scanning ${image}"
+            trivy image \
+              --quiet \
+              --scanners vuln \
+              --severity CRITICAL,HIGH \
+              --ignore-unfixed \
+              --format sarif \
+              --output "trivy-results/${safe}.sarif" \
+              "$image" || echo "::warning::Trivy scan failed for ${image}"
+            echo "::endgroup::"
+          done < images.txt
+
+      - name: Upload SARIF results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results
+          category: trivy-image-scan

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,35 @@
+# See https://pre-commit.com for usage. Mirrors the checks run in CI
+# (format.yaml + validate-and-diff.yml) so issues are caught before pushing.
+# Hook versions are kept up to date by Renovate (`:enablePreCommit`).
+minimum_pre_commit_version: "3.0.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-added-large-files
+
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.8.4
+    hooks:
+      - id: prettier
+        files: \.(ya?ml|json)$
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        args: ["-c", ".github/yamllint.yaml"]
+
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        args: ["-i", "2", "-ci", "-s"]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":enablePreCommit"],
+  "timezone": "Asia/Jerusalem",
+  "schedule": ["after 10pm every weekday", "before 6am every weekday", "every weekend"],
+  "platformAutomerge": true,
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true,
+    "minimumReleaseAge": "7 days"
+  },
   "argocd": {
     "managerFilePatterns": ["/\\.yaml$/"]
   },
@@ -8,6 +16,25 @@
     "managerFilePatterns": ["/\\.yaml$/"]
   },
   "packageRules": [
+    {
+      "description": "Auto-merge low-risk updates after a soak period for stability",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+      "automerge": true,
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Require manual review for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["major-update"]
+    },
+    {
+      "description": "Group and auto-merge GitHub Actions updates after a short soak",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions",
+      "automerge": true,
+      "minimumReleaseAge": "7 days"
+    },
     {
       "description": "Block Ubuntu base-image version tags (e.g. 20.04.1) on LinuxServer images",
       "matchDatasources": ["docker"],

--- a/scripts/new-service.sh
+++ b/scripts/new-service.sh
@@ -49,7 +49,7 @@ echo "================================"
 echo ""
 
 # Prompt for service details
-read -p "Service name (e.g., radarr): " SERVICE_NAME
+read -rp "Service name (e.g., radarr): " SERVICE_NAME
 if [[ -z $SERVICE_NAME ]]; then
   echo -e "${RED}Error: Service name is required${NC}"
   exit 1
@@ -70,30 +70,30 @@ for dir in "$REPO_ROOT/services"/*/; do
 done
 echo "  $i) [NEW] Create new category"
 
-read -p "Select category [1-$i]: " CAT_CHOICE
+read -rp "Select category [1-$i]: " CAT_CHOICE
 
 if [[ $CAT_CHOICE -eq $i ]]; then
-  read -p "Enter new category name: " CATEGORY
-  read -p "Enter namespace (default: $CATEGORY): " NAMESPACE
+  read -rp "Enter new category name: " CATEGORY
+  read -rp "Enter namespace (default: $CATEGORY): " NAMESPACE
   NAMESPACE=${NAMESPACE:-$CATEGORY}
   echo -e "${YELLOW}Will create new category: $CATEGORY${NC}"
 elif [[ $CAT_CHOICE -ge 1 && $CAT_CHOICE -lt $i ]]; then
   CATEGORY="${CATEGORIES[$((CAT_CHOICE - 1))]}"
-  read -p "Enter namespace (default: $CATEGORY): " NAMESPACE
+  read -rp "Enter namespace (default: $CATEGORY): " NAMESPACE
   NAMESPACE=${NAMESPACE:-$CATEGORY}
 else
   echo -e "${RED}Invalid choice${NC}"
   exit 1
 fi
 
-read -p "Container image (e.g., lscr.io/linuxserver/radarr:latest): " IMAGE
+read -rp "Container image (e.g., lscr.io/linuxserver/radarr:latest): " IMAGE
 
 # Fetch image digest
 DIGEST=""
 if DIGEST=$(get_image_digest "$IMAGE"); then
   echo -e "${GREEN}✓ Digest: $DIGEST${NC}"
 else
-  read -p "Continue without digest? [Y/n]: " SKIP_DIGEST
+  read -rp "Continue without digest? [Y/n]: " SKIP_DIGEST
   SKIP_DIGEST=${SKIP_DIGEST:-Y}
   if [[ ! $SKIP_DIGEST =~ ^[Yy] ]]; then
     echo -e "${RED}Aborted${NC}"
@@ -101,12 +101,12 @@ else
   fi
 fi
 
-read -p "Container port (e.g., 7878): " PORT
+read -rp "Container port (e.g., 7878): " PORT
 
 # Ingress configuration
 echo ""
 echo -e "${YELLOW}Ingress Configuration${NC}"
-read -p "Enable ingress? [Y/n]: " INGRESS_ENABLED
+read -rp "Enable ingress? [Y/n]: " INGRESS_ENABLED
 INGRESS_ENABLED=${INGRESS_ENABLED:-Y}
 
 if [[ $INGRESS_ENABLED =~ ^[Yy] ]]; then
@@ -114,7 +114,7 @@ if [[ $INGRESS_ENABLED =~ ^[Yy] ]]; then
   echo "  1) internal (*.$DOMAIN_INTERNAL)"
   echo "  2) public (*.$DOMAIN_PUBLIC)"
   echo "  3) media (*.$DOMAIN_MEDIA)"
-  read -p "Select [1-3, default=1]: " DOMAIN_CHOICE
+  read -rp "Select [1-3, default=1]: " DOMAIN_CHOICE
   DOMAIN_CHOICE=${DOMAIN_CHOICE:-1}
 
   case $DOMAIN_CHOICE in
@@ -124,13 +124,13 @@ if [[ $INGRESS_ENABLED =~ ^[Yy] ]]; then
     *) DOMAIN_TYPE="internal" ;;
   esac
 
-  read -p "Require Authentik middleware? [Y/n]: " AUTH
+  read -rp "Require Authentik middleware? [Y/n]: " AUTH
   AUTH=${AUTH:-Y}
 
-  read -p "Enable rate limiting? [Y/n]: " RATELIMIT
+  read -rp "Enable rate limiting? [Y/n]: " RATELIMIT
   RATELIMIT=${RATELIMIT:-Y}
 
-  read -p "Custom subdomain (default: $SERVICE_NAME): " SUBDOMAIN
+  read -rp "Custom subdomain (default: $SERVICE_NAME): " SUBDOMAIN
   SUBDOMAIN=${SUBDOMAIN:-$SERVICE_NAME}
 
   INGRESS_BLOCK="
@@ -148,11 +148,11 @@ fi
 # Persistence configuration
 echo ""
 echo -e "${YELLOW}Persistence Configuration${NC}"
-read -p "Need persistent storage? [Y/n]: " PERSISTENCE
+read -rp "Need persistent storage? [Y/n]: " PERSISTENCE
 PERSISTENCE=${PERSISTENCE:-Y}
 
 if [[ $PERSISTENCE =~ ^[Yy] ]]; then
-  read -p "Storage size (default: 1Gi): " STORAGE_SIZE
+  read -rp "Storage size (default: 1Gi): " STORAGE_SIZE
   STORAGE_SIZE=${STORAGE_SIZE:-1Gi}
 
   PERSISTENCE_BLOCK="


### PR DESCRIPTION
## Changes

### Trivy image scanning (`.github/workflows/image-scan.yml`)
- Extracts every image referenced in `services/**` and `infrastructure/**` `values.yaml` (57 images today) via `yq`.
- Scans each with Trivy (`CRITICAL,HIGH`, `--ignore-unfixed`) and uploads SARIF to the **GitHub Security** tab.
- Weekly cron (Mon 06:00 UTC) + `workflow_dispatch`. **Advisory only** — never blocks merges.

### Renovate safety gates (`renovate.json`)
- Auto-merge `minor`/`patch`/`digest` after a **14-day** soak; security fixes after **7 days**; `major` stays manual (`major-update` label).
- Off-hours `schedule` (Asia/Jerusalem), `platformAutomerge`, group GitHub Actions.
- Enable the `:enablePreCommit` manager so Renovate keeps the new pre-commit hooks updated.

### Pre-commit (`.pre-commit-config.yaml`)
- Mirrors CI: prettier, shfmt, shellcheck, yamllint (`.github/yamllint.yaml`) + basic hygiene hooks.
- Fixes pre-existing `SC2162` (`read` → `read -r`) in `scripts/new-service.sh` so the repo passes its own shellcheck hook.

Verified locally with `pre-commit run --all-files` (all hooks pass).