### PR TITLE
fix(ci): merge Trivy SARIF into a single run before upload

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -74,9 +74,50 @@ jobs:
             echo "::endgroup::"
           done < images.txt
 
+      - name: Merge per-image SARIF into a single run
+        if: always()
+        run: |
+          set -uo pipefail
+          valid=()
+          for f in trivy-results/*.sarif; do
+            [ -e "$f" ] || continue
+            if jq -e 'has("runs") and (.runs | type == "array")' "$f" >/dev/null 2>&1; then
+              valid+=("$f")
+            else
+              echo "::warning::Skipping invalid SARIF file: ${f}"
+            fi
+          done
+
+          # An empty run still clears alerts from previous scans for this category.
+          if [ ${#valid[@]} -eq 0 ]; then
+            printf '%s' '{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[{"tool":{"driver":{"name":"Trivy","rules":[]}},"results":[]}]}' > trivy.sarif
+            echo "No valid SARIF inputs; uploading an empty result set"
+            exit 0
+          fi
+
+          # CodeQL no longer accepts multiple runs under one category, so collapse
+          # every per-image run into one: concatenate results, dedupe the rule set
+          # by id, and remap each result's ruleIndex into the merged rule list.
+          jq -s '
+            (map(.runs[0])) as $runs
+            | ([ $runs[] | .tool.driver.rules[]? ] | unique_by(.id)) as $rules
+            | ($rules | map(.id)) as $ids
+            | {
+                version: (.[0].version // "2.1.0"),
+                "$schema": (.[0]["$schema"] // "https://json.schemastore.org/sarif-2.1.0.json"),
+                runs: [{
+                  tool: { driver: ($runs[0].tool.driver | .rules = $rules) },
+                  results: [$runs[] | .results[]? | .ruleId as $rid | (.ruleIndex = ($ids | index($rid)))],
+                  columnKind: ($runs[0].columnKind // "utf16CodeUnits"),
+                  originalUriBaseIds: ($runs[0].originalUriBaseIds // {"ROOTPATH": {"uri": "file:///"}})
+                }]
+              }
+          ' "${valid[@]}" > trivy.sarif
+          echo "Merged $(jq '.runs[0].results | length' trivy.sarif) findings from ${#valid[@]} image(s)"
+
       - name: Upload SARIF results
         if: always()
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: trivy-results
+          sarif_file: trivy.sarif
           category: trivy-image-scan


### PR DESCRIPTION
## Problem
Running the new `Image vulnerability scan` workflow fails at upload:

> The CodeQL Action does not support uploading multiple SARIF runs with the same category.

As of the [2025-07-21 Code Scanning change](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/), CodeQL no longer combines multiple SARIF runs uploaded under one category. The workflow wrote **one SARIF file per image** into `trivy-results/` and uploaded the whole **directory** under a single `category: trivy-image-scan` → many runs, one category → rejected.

## Fix
Add a merge step that collapses every per-image run into a **single run** before upload:
- concatenate all `results`
- dedupe the rule set by `id`
- remap each result's `ruleIndex` into the merged rule list

Then upload the single `trivy.sarif` (unchanged category).

Why a single run rather than a per-image category? A single category re-uploaded each run automatically **clears alerts for images that were removed**. Per-image categories would leave stale alerts forever for any image dropped from the repo.

### Edge cases handled
- **Overlapping CVEs** across images → rules dedupe, `ruleIndex` remaps correctly.
- **Failed/partial scans** (invalid or empty `.sarif`) → skipped with a warning.
- **No findings / all scans failed** → uploads an empty run so the category clears previous alerts.

## Verification
Tested locally with real Trivy SARIF output (`node:16-slim` 29 findings + `python:3.8-slim` 39 findings + `alpine:3.18` 0 findings):
- merged → **1 run, 43 rules, 68 results, 0 ruleIndex mismatches**, valid JSON
- forced 100% CVE overlap → rules stay deduped, indices remap, 0 mismatches
- invalid/empty input files → skipped; all-empty → valid empty run
- `pre-commit` (prettier + yamllint) passes