### PR TITLE
feat: default resource requests + Authentik server HA

### DIFF
--- a/infrastructure/controllers/authentik/values.yaml
+++ b/infrastructure/controllers/authentik/values.yaml
@@ -49,6 +49,17 @@ authentik:
   disable_update_check: true
   disable_startup_analytics: true
 server:
+  replicas: 2
+  pdb:
+    enabled: true
+    minAvailable: 1
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: server
   resources:
     requests:
       memory: 1Gi

--- a/templates/common.yaml
+++ b/templates/common.yaml
@@ -6,6 +6,10 @@ controllers:
   main:
     containers:
       main:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
         env:
           TZ: "Asia/Jerusalem"
           PUID: "1000"


### PR DESCRIPTION
## Summary
P1 hardening (B3).

### 1. Default resource requests (value cascade)
Adds a requests-only floor (`cpu: 10m` / `memory: 64Mi`) to the default main container in `templates/common.yaml`. It cascades to every `services/**` app and is overridden per-service via Helm deep-merge. **No limits** are set, so nothing can be OOM-killed or CPU-throttled by this default. The 18 services that set no resources gain a scheduling floor; the rest keep their own values (and inherit the cpu floor if unset).

### 2. Authentik server HA + PDB
The Authentik server is stateless (state in external postgres + redis), so it now runs `replicas: 2` with a `PodDisruptionBudget` (`minAvailable: 1`) and a soft hostname topology spread so replicas prefer separate nodes and single-node drains stay unblocked. Worker unchanged.

#### Deliberate exclusions
- **Traefik** is a DaemonSet (already one pod per node, HA); `kubectl drain` ignores DaemonSet pods, so scaling/PDB don't apply.
- **postgres / redis** are single-replica stateful; real HA needs replication/clustering — out of scope.

## Verification
- `helm template` (bjw-s app-template): a no-resources service (mosquitto) inherits the floor; `stirling-pdf` keeps its 768Mi memory request and gains the cpu floor.
- `helm template` (goauthentik): renders PDB + server `replicas: 2` + topology spread; worker stays at 1.
- `pre-commit run --all-files` green.