### PR TITLE
docs: add governance docs (ADRs, BACKLOG, SECURITY)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,16 @@
+# Backlog & Known Gaps
+
+An informal, single place for intentional gaps and not-yet-implemented ideas, so they don't
+live as scattered TODOs. Significant *decisions* are recorded as ADRs under `docs/adr/`.
+
+## Known gaps
+
+- **Runtime threat detection:** No host/container runtime security agent (e.g. Falco) is
+  deployed. Edge/web traffic is filtered by CrowdSec.
+- **Alerting depth:** No custom Prometheus alert rules and no blackbox / synthetic (uptime)
+  monitoring yet — only the monitoring stack's built-in alerts.
+- **Diagrams:** Architecture is documented in prose only; no diagrams-as-code.
+- **Contributor docs:** No CONTRIBUTING guide, issue/PR templates, or CODEOWNERS.
+- **Network policies:** No cluster-authored default-deny NetworkPolicies; only chart-shipped
+  policies are in effect (see `docs/adr/0008-networkpolicies-declined.md`).
+- **CNI:** A Cilium migration is deferred (see `docs/adr/0007-cni-flannel-kube-router.md`).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -7,8 +7,9 @@ live as scattered TODOs. Significant *decisions* are recorded as ADRs under `doc
 
 - **Runtime threat detection:** No host/container runtime security agent (e.g. Falco) is
   deployed. Edge/web traffic is filtered by CrowdSec.
-- **Alerting depth:** No custom Prometheus alert rules and no blackbox / synthetic (uptime)
-  monitoring yet — only the monitoring stack's built-in alerts.
+- **Alerting depth:** Only a few component-specific custom alerts exist (e.g. kube-vip,
+  CrowdSec); there is no broad custom Prometheus alert coverage and no blackbox / synthetic
+  (uptime) monitoring yet.
 - **Diagrams:** Architecture is documented in prose only; no diagrams-as-code.
 - **Contributor docs:** No CONTRIBUTING guide, issue/PR templates, or CODEOWNERS.
 - **Network policies:** No cluster-authored default-deny NetworkPolicies; only chart-shipped

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+This repository is part of a **personal homelab**, maintained for learning and home use. It is
+provided **as-is**, with **no service-level agreement** and no guarantee of timely fixes.
+
+## Reporting a vulnerability
+
+If you find a security issue, please report it **privately** — do not open a public issue that
+discloses details. Use GitHub's private vulnerability reporting if available, or contact the
+repository owner directly, and allow time for the issue to be addressed before any public
+disclosure.
+
+## Supported versions
+
+Only the current state of the default branch (`main`) is maintained. Older commits, tags, and
+branches receive no security support.

--- a/docs/adr/0001-use-k3s-over-talos.md
+++ b/docs/adr/0001-use-k3s-over-talos.md
@@ -1,0 +1,35 @@
+# ADR 0001: Use Debian + K3s over Talos
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The cluster needs a node OS and Kubernetes distribution. Two broad options were weighed:
+an immutable, API-driven appliance OS (Talos) versus a general-purpose Linux (Debian) running
+a lightweight Kubernetes distribution (K3s). The homelab runs GPU workloads (SR-IOV) and some
+non-Kubernetes / device-attached needs, and is operated hands-on by a single maintainer.
+
+## Decision
+
+Run Debian (current: trixie) on the nodes with K3s as the Kubernetes distribution.
+
+## Rationale
+
+- **GPU SR-IOV and device flexibility:** DKMS/kernel-pinned drivers and direct device access
+  are well-supported on Debian; the equivalent is harder on an immutable appliance OS that
+  relies on system extensions.
+- **Operability:** Full SSH/apt access and a battle-tested ecosystem suit hands-on
+  maintenance and debugging.
+- **Low friction:** K3s is a single, lightweight distribution with sane defaults (it bundles
+  flannel, a service LB, traefik — we selectively disable what we replace).
+
+Talos's smaller, immutable attack surface and declarative `talosctl` config are real
+benefits, but do not outweigh GPU/device flexibility and familiarity for this homelab.
+
+## Consequences
+
+- Larger attack surface than an immutable OS; mitigated by keeping nodes patched and minimal.
+- Node config is managed declaratively via Packer + cloud-init + Ansible rather than a single
+  appliance API.
+- Revisit if GPU/device needs disappear or immutability becomes a priority.

--- a/docs/adr/0002-argocd-app-of-apps.md
+++ b/docs/adr/0002-argocd-app-of-apps.md
@@ -1,0 +1,30 @@
+# ADR 0002: GitOps via ArgoCD app-of-apps (ApplicationSet + RollingSync)
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The cluster's workloads and infrastructure must be deployed declaratively and in a
+dependency-aware order (CRDs before the controllers that need them, foundational services
+before the apps that depend on them).
+
+## Decision
+
+Use ArgoCD with an app-of-apps pattern: a single bootstrap `ApplicationSet` (`cluster-apps`)
+generates one Argo `Application` per discovered `app.yaml`, and a `RollingSync` strategy
+orders rollout by a `deploy-phase` label.
+
+## Rationale
+
+- **One entry point:** New apps are added by committing an `app.yaml`; the ApplicationSet
+  discovers and renders them — no per-app Application boilerplate.
+- **Ordered rollout:** `RollingSync` steps process phases in order:
+  `crds → foundation → controllers → services`, so dependencies come up before dependents.
+- **Declarative & auditable:** All state lives in Git and is reconciled by Argo.
+
+## Consequences
+
+- A stuck/failed app in an early phase **blocks** later phases until resolved — ordering
+  guarantees come at the cost of a global rollout dependency.
+- Each app must declare its `deployPhase` (a default applies per category).

--- a/docs/adr/0003-bjw-s-app-template.md
+++ b/docs/adr/0003-bjw-s-app-template.md
@@ -1,0 +1,29 @@
+# ADR 0003: Use the bjw-s app-template chart for services
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The cluster runs ~60 services, most of which are simple "one Deployment + Service + optional
+Ingress/PVC" workloads. Hand-writing manifests or a bespoke chart per service would be
+repetitive and inconsistent.
+
+## Decision
+
+Render services from the common `app-template` chart (`bjw-s-labs`, version `5.0.1`,
+`https://bjw-s-labs.github.io/helm-charts`), configured through a layered value cascade
+(`templates/globals.yaml` → `templates/common.yaml` → per-family extras → service `values.yaml`).
+
+## Rationale
+
+- **DRY:** One well-maintained chart expresses controllers/containers/services/ingress/PVCs
+  for the whole fleet; per-service files carry only what differs.
+- **Consistent defaults:** Shared `common.yaml` applies cluster-wide conventions uniformly.
+- **Pinned:** A single chart version (`5.0.1`) is upgraded deliberately in one place.
+
+## Consequences
+
+- Services inherit the chart's structure (`controllers.main.containers.main`...); unusual
+  workloads may need raw manifests (supported via `manifests: true`).
+- `infrastructure/**` apps intentionally do **not** consume `common.yaml`.

--- a/docs/adr/0004-sealed-secrets.md
+++ b/docs/adr/0004-sealed-secrets.md
@@ -1,0 +1,31 @@
+# ADR 0004: Use sealed-secrets for secret management
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+Secrets must be stored in Git (GitOps) without exposing plaintext, and managed by a single
+maintainer without standing external infrastructure.
+
+## Decision
+
+Use Bitnami **sealed-secrets** (chart version `2.19.0`, deploy phase `foundation`). Secrets are
+encrypted to `SealedSecret` resources committed to Git; the in-cluster controller decrypts
+them into native `Secret`s.
+
+## Rationale
+
+- **No external dependency:** Unlike an external-secrets operator backed by a cloud/Vault
+  secret store, sealed-secrets needs no external service to operate — simpler and cheaper for
+  a homelab.
+- **Encrypted at rest in Git:** Ciphertext is safe to commit; only the cluster's controller
+  key can decrypt.
+- **Fits the bootstrap order:** Runs in the `foundation` phase so secrets exist before
+  dependent controllers/services.
+
+## Consequences
+
+- The controller's private key is the root of trust — its backup/DR is critical (handled by
+  the separate secrets-backup tooling and `cert-backup`).
+- No native secret rotation from an upstream store; rotation is manual/redeploy.

--- a/docs/adr/0005-metallb-l2.md
+++ b/docs/adr/0005-metallb-l2.md
@@ -1,0 +1,29 @@
+# ADR 0005: MetalLB in L2 mode for LoadBalancer IPs
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+Bare-metal Kubernetes has no cloud load-balancer. `Service` type `LoadBalancer` needs an
+implementation to assign and announce external IPs on the home LAN. (K3s's bundled servicelb
+is disabled.)
+
+## Decision
+
+Use **MetalLB** in **L2 (ARP) mode** with a single `IPAddressPool` covering the LAN addresses
+used by ingress and a few directly-exposed services (external, internal, Home Assistant, and
+two qBittorrent endpoints).
+
+## Rationale
+
+- **Simplicity:** L2/ARP needs no BGP-capable router or extra network config — it just answers
+  ARP for the pool addresses. Appropriate for a flat home network.
+- **Sufficient scale:** A handful of LoadBalancer services; no need for ECMP/BGP throughput.
+
+## Consequences
+
+- L2 mode funnels traffic for a given IP through one elected node (failover, not load
+  spreading) — acceptable at homelab scale.
+- Pool addresses must stay outside the DHCP range to avoid conflicts.
+- Revisit BGP mode only if multi-node ingress throughput becomes a constraint.

--- a/docs/adr/0006-kube-vip-control-plane-vip.md
+++ b/docs/adr/0006-kube-vip-control-plane-vip.md
@@ -1,0 +1,28 @@
+# ADR 0006: kube-vip for the control-plane VIP
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+The Kubernetes API should be reachable at a single, stable address that survives the loss of
+any individual control-plane node, rather than pinning clients to one node IP.
+
+## Decision
+
+Run **kube-vip** as a DaemonSet to provide a virtual IP (`10.9.9.99`) for the control plane,
+elected via Kubernetes leases. K3s is installed with this VIP in its `--tls-san`.
+
+## Rationale
+
+- **HA API endpoint:** The VIP floats to a healthy control-plane node, so kubeconfig and
+  in-cluster API traffic don't depend on one host.
+- **Lease-based election:** Uses Kubernetes leader-election (no extra VRRP/keepalived stack).
+- **Cert validity:** Including the VIP in `--tls-san` keeps the API certificate valid for the
+  VIP address.
+
+## Consequences
+
+- The VIP must be a free, static LAN address outside DHCP.
+- Distinct from service LoadBalancer IPs (MetalLB, ADR 0005) — kube-vip here covers only the
+  control-plane endpoint.

--- a/docs/adr/0007-cni-flannel-kube-router.md
+++ b/docs/adr/0007-cni-flannel-kube-router.md
@@ -1,0 +1,46 @@
+# ADR 0007: CNI — keep Flannel + kube-router; defer Cilium
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+A migration to Cilium was considered (for L7/DNS policy, Hubble observability, kube-proxy
+replacement, and to consolidate MetalLB). A prior assumption held that Flannel cannot enforce
+NetworkPolicy and that a CNI change was therefore required. Investigation disproved this: K3s
+ships Flannel **and** an embedded kube-router NetworkPolicy controller, and the cluster does
+**not** pass `--disable-network-policy` — so standard `networking.k8s.io/v1` NetworkPolicies
+are already enforced (confirmed by chart-shipped policies in effect today).
+
+## Decision
+
+Stay on **Flannel + embedded kube-router** (and MetalLB + kube-vip + Traefik as-is). Do not
+migrate to Cilium at this time.
+
+## Rationale
+
+- **No concrete need:** Interest in Cilium is curiosity / "best practice," not a missing
+  capability.
+- **The forcing premise was false:** NetworkPolicy is already enforced; nothing is blocked by
+  the current CNI.
+- **Migration risk outweighs benefit:** An in-place CNI swap on a running cluster (removing
+  Flannel + kube-proxy, possibly MetalLB) carries real downtime risk; the cluster is relied
+  upon day-to-day.
+- **Portability protects the option:** Standard NetworkPolicies are CNI-portable; Cilium
+  implements the same API, so a future migration is re-test, not rewrite.
+
+## Revisit triggers
+
+Re-open (toward Cilium) if any become true:
+
+1. L7/DNS-aware policy is needed (e.g. egress allow-lists by hostname).
+2. Observability gaps make "what talks to what" painful and Hubble would clearly help.
+3. The cluster is being rebuilt anyway (near-zero marginal cost).
+4. A deliberate goal to consolidate Flannel + kube-proxy + MetalLB into one platform.
+5. A NetworkPolicy edge case kube-router cannot satisfy.
+
+## Consequences
+
+- No code or runtime change.
+- A future hands-on Cilium evaluation, if desired, should run on a disposable VM/cluster, not
+  the live cluster.

--- a/docs/adr/0008-networkpolicies-declined.md
+++ b/docs/adr/0008-networkpolicies-declined.md
@@ -1,0 +1,29 @@
+# ADR 0008: Cluster-authored NetworkPolicies declined (for now)
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+A zero-trust, default-deny NetworkPolicy rollout (per-namespace / per-service) was considered.
+The CNI already enforces NetworkPolicy (see ADR 0007), so this was feasible on the current
+stack without any CNI change.
+
+## Decision
+
+Do not author a cluster-wide default-deny / per-service NetworkPolicy set at this time. The
+existing chart-shipped policies remain in effect.
+
+## Rationale
+
+- **A want, not a need:** No current security driver justifies the authoring and ongoing
+  maintenance burden across ~60 services.
+- **Maintenance cost:** A default-deny posture requires enumerating and maintaining allow
+  rules for every legitimate flow; high churn for a single maintainer.
+- **Reversible:** Can be adopted later; policies are CNI-portable (see ADR 0007).
+
+## Consequences
+
+- East-west traffic is not locked down beyond what individual charts ship.
+- Reconsider alongside any change to the threat model or if ADR 0007's triggers move the
+  cluster toward Cilium (where Hubble would ease safe authoring).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records (ADRs)
+
+This directory records significant technical decisions for the homelab — *why* the stack is
+the way it is. Each ADR is a short, immutable record: when a decision changes, add a new ADR
+that supersedes the old one (don't rewrite history).
+
+## How to add an ADR
+
+1. Copy `template.md` to `NNNN-kebab-title.md` (next free number).
+2. Fill in Status, Context, Decision, Rationale, Consequences.
+3. Add a row to the index below.
+
+## Index
+
+| #    | Decision                                              | Status   |
+| ---- | ----------------------------------------------------- | -------- |
+| 0001 | [Use K3s over Talos](0001-use-k3s-over-talos.md)      | Accepted |
+| 0002 | [ArgoCD app-of-apps](0002-argocd-app-of-apps.md)      | Accepted |
+| 0003 | [bjw-s app-template for services](0003-bjw-s-app-template.md) | Accepted |
+| 0004 | [sealed-secrets for secret management](0004-sealed-secrets.md) | Accepted |
+| 0005 | [MetalLB (L2) for LoadBalancer IPs](0005-metallb-l2.md) | Accepted |
+| 0006 | [kube-vip for the control-plane VIP](0006-kube-vip-control-plane-vip.md) | Accepted |
+| 0007 | [CNI: Flannel + kube-router; defer Cilium](0007-cni-flannel-kube-router.md) | Accepted |
+| 0008 | [NetworkPolicies declined](0008-networkpolicies-declined.md) | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,20 @@
+# ADR NNNN: <decision title>
+
+- **Status:** Proposed | Accepted | Deferred | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD
+
+## Context
+
+What is the situation and the forces at play? What constraints apply?
+
+## Decision
+
+What did we decide to do?
+
+## Rationale
+
+Why this option, and why not the alternatives considered?
+
+## Consequences
+
+What becomes easier or harder as a result? Any follow-ups or trade-offs?


### PR DESCRIPTION
Adds centralized governance documentation:

- `docs/adr/` — ADR index, template, and 8 seed records (K3s-over-Talos, app-of-apps, bjw-s app-template, sealed-secrets, MetalLB L2, kube-vip, CNI decision, NetworkPolicies declined).
- `BACKLOG.md` — informal known-gaps list.
- `SECURITY.md` — personal-homelab security policy.

Docs-only; no manifest or runtime changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>