### PR TITLE
fix(qbit-manage): add orphaned min_file_age_minutes grace period

### DIFF
--- a/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
+++ b/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
@@ -78,7 +78,7 @@ data:
       split_by_category: false
 
     orphaned:
-      empty_after_x_days: 7
+      empty_after_x_days: 3
       min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"

--- a/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
+++ b/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
@@ -74,11 +74,11 @@ data:
 
     recyclebin:
       enabled: true
-      empty_after_x_days: 30
+      empty_after_x_days: 3
       split_by_category: false
 
     orphaned:
-      empty_after_x_days: 3
+      empty_after_x_days: 7
       min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"

--- a/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
+++ b/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
@@ -79,6 +79,7 @@ data:
 
     orphaned:
       empty_after_x_days: 7
+      min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"
         - "**/*.!qB"

--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -107,7 +107,7 @@ data:
       split_by_category: false
 
     orphaned:
-      empty_after_x_days: 7
+      empty_after_x_days: 3
       min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"

--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -108,8 +108,6 @@ data:
 
     orphaned:
       empty_after_x_days: 7
-      # Protect freshly-completed downloads from being moved to .orphaned before
-      # the *arr apps have had a chance to import them (rem_orphaned runs every 30m).
       min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"

--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -107,7 +107,7 @@ data:
       split_by_category: false
 
     orphaned:
-      empty_after_x_days: 3
+      empty_after_x_days: 7
       min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"

--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -108,6 +108,9 @@ data:
 
     orphaned:
       empty_after_x_days: 7
+      # Protect freshly-completed downloads from being moved to .orphaned before
+      # the *arr apps have had a chance to import them (rem_orphaned runs every 30m).
+      min_file_age_minutes: 60
       exclude_patterns:
         - "**/.DS_Store"
         - "**/*.!qB"


### PR DESCRIPTION
## Problem

`rem_orphaned` runs every 30 min (`QBT_SCHEDULE=30`) with `min_file_age_minutes` unset, so qbit_manage defaults it to **0** (no age protection). A just-completed download can therefore be classified as orphaned and moved to `/data/torrents/.orphaned` within seconds of qBittorrent finalizing it — **before** Sonarr/Radarr import.

### Observed incident (Orphan Black S05)
- 16:37:45 — season-pack torrent completed (all 10 files on disk)
- 16:38:26 — `rem_orphaned` ran and moved **S05E01 & S05E02** to `.orphaned`
- 16:44 — Sonarr imported S05E03–E10; E01/E02 were already gone → import blocked

This has triggered 3× in two days.

## Fix

Set `orphaned.min_file_age_minutes: 60` so freshly-completed files are protected from the orphaned sweep until the *arr apps import them. (qbit_manage's sample recommends 30; 60 gives headroom over the 30-min schedule and observed import lag.)

## Deploy note
The `qbit-manage` Argo app has `automated.enabled: false`, so this needs a manual sync after merge to take effect.