### PR TITLE
feat(falco): add Falco runtime security (eBPF) with WebUI + ntfy alerts

### DIFF
--- a/infrastructure/system/falco/app.yaml
+++ b/infrastructure/system/falco/app.yaml
@@ -1,0 +1,8 @@
+name: falco
+namespace: falco
+deployPhase: services
+manifests: true
+chart:
+  repo: https://falcosecurity.github.io/charts
+  name: falco
+  version: 9.1.0

--- a/infrastructure/system/falco/manifests/ingressroute.yaml
+++ b/infrastructure/system/falco/manifests/ingressroute.yaml
@@ -1,0 +1,21 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: falco-ui
+  namespace: falco
+spec:
+  entryPoints:
+    - websec-int
+  routes:
+    - match: Host(`falco.internal.starktastic.net`)
+      kind: Rule
+      services:
+        - name: falco-falcosidekick-ui
+          port: 2802
+      middlewares:
+        - name: authentik-middleware
+          namespace: authentik
+  tls:
+    store:
+      name: default
+      namespace: traefik-system

--- a/infrastructure/system/falco/values.yaml
+++ b/infrastructure/system/falco/values.yaml
@@ -10,6 +10,7 @@ resources:
     cpu: 100m
     memory: 256Mi
   limits:
+    cpu: null # drop the chart's default 1000m CPU limit (avoid throttling/dropped events)
     memory: 512Mi
 
 falco:

--- a/infrastructure/system/falco/values.yaml
+++ b/infrastructure/system/falco/values.yaml
@@ -1,0 +1,64 @@
+# Falco runtime security — learning-mode deployment.
+# Detection only (no response actions, no heavy rule tuning).
+
+driver:
+  kind: modern_ebpf
+
+# Falco core
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+falco:
+  rules_files:
+    - /etc/falco/falco_rules.yaml
+    - /etc/falco/falco-incubating_rules.yaml
+    - /etc/falco/falco_rules.local.yaml
+    - /etc/falco/rules.d
+  json_output: true
+
+# Pull default + incubating rulesets (incubating:6 pairs with falco-rules:5 for Falco 0.44.x)
+# NOTE: refs live under falcoctl.config.artifact.* (falcoctl.artifact.* is the init/sidecar
+# container config and has no refs field — putting refs there is silently ignored).
+falcoctl:
+  config:
+    artifact:
+      install:
+        refs: [falco-rules:5, falco-incubating-rules:6]
+      follow:
+        refs: [falco-rules:5, falco-incubating-rules:6]
+
+falcosidekick:
+  enabled: true
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      memory: 128Mi
+  config:
+    # High-severity events -> existing Alertmanager -> alertmanager-ntfy -> ntfy
+    alertmanager:
+      hostport: "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"
+      endpoint: "/api/v2/alerts"
+      minimumpriority: "critical"
+      extralabels: "source:falco"
+  webui:
+    enabled: true
+    # UI is protected by Authentik forward-auth at the ingress; disable built-in basic auth.
+    disableauth: true
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    redis:
+      # Ephemeral, in-namespace event store for the UI (transient exploration data).
+      storageEnabled: false
+      customConfig:
+        - "maxmemory 256mb"
+        - "maxmemory-policy allkeys-lfu"


### PR DESCRIPTION
Adds Falco runtime threat detection (learning mode) as a new GitOps app.

- Chart `falcosecurity/falco` 9.1.0, modern eBPF driver, `deployPhase: services` (last phase, limits rollout blast radius).
- Default + incubating rulesets (no pre-tuning).
- Falcosidekick fans out: all events to a WebUI (ephemeral Redis), high-severity (>= critical) to ntfy via the existing Alertmanager bridge.
- WebUI at `falco.internal.starktastic.net` behind Authentik SSO (built-in UI auth disabled).
- No SealedSecret required.

Detection-only; no response actions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>