### PR TITLE
feat: blackbox/synthetic monitoring + custom alert rules

### DIFF
--- a/infrastructure/system/cert-manager/manifests/templates/prometheus-rules.yaml
+++ b/infrastructure/system/cert-manager/manifests/templates/prometheus-rules.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cert-manager-alerts
+  namespace: cert-manager
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: cert-manager
+      rules:
+        - alert: CertManagerCertNotReady
+          expr: certmanager_certificate_ready_status{condition="True"} == 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: {{ `"Certificate not ready ({{ $labels.name }})"` }}
+            description: {{ `"Certificate {{ $labels.namespace }}/{{ $labels.name }} has not been Ready for 15 minutes (renewal likely failing)."` }}
+        - alert: CertManagerCertExpiringSoon
+          expr: certmanager_certificate_expiration_timestamp_seconds > 0 and certmanager_certificate_expiration_timestamp_seconds - time() < 10 * 24 * 3600
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: {{ `"Certificate expiring soon ({{ $labels.name }})"` }}
+            description: {{ `"Certificate {{ $labels.namespace }}/{{ $labels.name }} expires in less than 10 days."` }}

--- a/services/home-automation/home-assistant/app.yaml
+++ b/services/home-automation/home-assistant/app.yaml
@@ -11,3 +11,4 @@ ingress:
   port: 8123
   auth: false
   rateLimit: false
+  probe: true

--- a/services/media/qbittorrent/app.yaml
+++ b/services/media/qbittorrent/app.yaml
@@ -10,3 +10,4 @@ ingress:
   serviceName: qbittorrent-main
   auth: true
   rateLimit: true
+  probe: true

--- a/services/operations/changedetection/app.yaml
+++ b/services/operations/changedetection/app.yaml
@@ -9,3 +9,4 @@ ingress:
   port: 5000
   auth: true
   rateLimit: false
+  probe: true

--- a/services/operations/filebrowser/app.yaml
+++ b/services/operations/filebrowser/app.yaml
@@ -8,3 +8,4 @@ ingress:
   port: 80
   auth: true
   rateLimit: true
+  probe: true

--- a/services/operations/karakeep/app.yaml
+++ b/services/operations/karakeep/app.yaml
@@ -9,3 +9,4 @@ ingress:
   port: 3000
   auth: false
   rateLimit: true
+  probe: true

--- a/services/operations/kube-prometheus-stack/app.yaml
+++ b/services/operations/kube-prometheus-stack/app.yaml
@@ -15,3 +15,4 @@ ingress:
   serviceName: "kube-prometheus-stack-grafana"
   auth: true
   rateLimit: false
+  probe: true

--- a/services/operations/kube-prometheus-stack/manifests/custom-rules.yaml
+++ b/services/operations/kube-prometheus-stack/manifests/custom-rules.yaml
@@ -1,0 +1,52 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: homelab-custom-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: backup-freshness
+      rules:
+        - alert: CronJobNotSucceededRecently
+          expr:
+            (time() - kube_cronjob_status_last_successful_time > 26 * 3600) and on(namespace, cronjob)
+            kube_cronjob_spec_suspend == 0
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "CronJob has not succeeded recently ({{ $labels.cronjob }})"
+            description:
+              "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} has not had a successful run in over 26 hours."
+    - name: pvc
+      rules:
+        - alert: PVCSpaceLow
+          expr: kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 0.10
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "PVC space low ({{ $labels.persistentvolumeclaim }})"
+            description:
+              "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 10% space remaining."
+        - alert: PVCSpaceCritical
+          expr: kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 0.05
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: "PVC space critical ({{ $labels.persistentvolumeclaim }})"
+            description:
+              "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} has less than 5% space remaining."
+    - name: alert-pipeline
+      rules:
+        - alert: AlertmanagerDown
+          expr: up{job=~".*alertmanager.*"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Alertmanager target down"
+            description: "An Alertmanager scrape target ({{ $labels.job }}) has been down for 5 minutes."

--- a/services/operations/listmonk/app.yaml
+++ b/services/operations/listmonk/app.yaml
@@ -9,3 +9,4 @@ ingress:
   port: 9000
   auth: false
   rateLimit: true
+  probe: true

--- a/services/operations/mealie/app.yaml
+++ b/services/operations/mealie/app.yaml
@@ -9,3 +9,4 @@ ingress:
   port: 9000
   auth: false
   rateLimit: true
+  probe: true

--- a/services/operations/ntfy/app.yaml
+++ b/services/operations/ntfy/app.yaml
@@ -10,3 +10,4 @@ ingress:
   port: 80
   auth: false
   rateLimit: true
+  probe: true

--- a/services/operations/paperless-ngx/app.yaml
+++ b/services/operations/paperless-ngx/app.yaml
@@ -9,3 +9,4 @@ ingress:
   port: 8000
   auth: false
   rateLimit: true
+  probe: true

--- a/services/operations/prometheus-blackbox-exporter/app.yaml
+++ b/services/operations/prometheus-blackbox-exporter/app.yaml
@@ -1,0 +1,8 @@
+name: prometheus-blackbox-exporter
+namespace: monitoring
+deployPhase: services
+manifests: true
+chart:
+  repo: https://prometheus-community.github.io/helm-charts
+  name: prometheus-blackbox-exporter
+  version: 11.13.0

--- a/services/operations/prometheus-blackbox-exporter/manifests/probe-external.yaml
+++ b/services/operations/prometheus-blackbox-exporter/manifests/probe-external.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: external-deps
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: icmp
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - 1.1.1.1
+      labels:
+        tier: external
+        probe_kind: icmp
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: external-dns
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: dns_cloudflare
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - 1.1.1.1
+      labels:
+        tier: external
+        probe_kind: dns
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: external-https
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: http_2xx
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - https://1.1.1.1
+      labels:
+        tier: external
+        probe_kind: https
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: alert-sink-ntfy-adapter
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: tcp_connect
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - alertmanager-ntfy.monitoring.svc.cluster.local:8000
+      labels:
+        service: alertmanager-ntfy
+        tier: alert-pipeline
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: infra-authentik
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: http_auth
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - https://auth.starktastic.net
+      labels:
+        service: authentik
+        tier: infra
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: infra-argocd
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: http_auth
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - https://argocd.internal.starktastic.net
+      labels:
+        service: argocd
+        tier: infra

--- a/services/operations/prometheus-blackbox-exporter/manifests/prometheus-rules.yaml
+++ b/services/operations/prometheus-blackbox-exporter/manifests/prometheus-rules.yaml
@@ -28,7 +28,7 @@ spec:
               "External-tier probe to {{ $labels.instance }} has been failing for 5 minutes (possible internet/DNS
               outage)."
         - alert: BlackboxProbeCertExpiringSoon
-          expr: probe_ssl_earliest_cert_expiry - time() < 10 * 24 * 3600
+          expr: probe_ssl_earliest_cert_expiry{tier=~"external|infra"} - time() < 10 * 24 * 3600
           for: 1h
           labels:
             severity: warning

--- a/services/operations/prometheus-blackbox-exporter/manifests/prometheus-rules.yaml
+++ b/services/operations/prometheus-blackbox-exporter/manifests/prometheus-rules.yaml
@@ -1,0 +1,37 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: blackbox-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: blackbox
+      rules:
+        - alert: BlackboxProbeFailed
+          expr: probe_success == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Blackbox probe failing ({{ $labels.instance }})"
+            description: "Probe to {{ $labels.instance }} has been failing for 5 minutes."
+        - alert: BlackboxExternalDepDown
+          expr: probe_success{tier="external"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "External dependency unreachable ({{ $labels.instance }})"
+            description:
+              "External-tier probe to {{ $labels.instance }} has been failing for 5 minutes (possible internet/DNS
+              outage)."
+        - alert: BlackboxProbeCertExpiringSoon
+          expr: probe_ssl_earliest_cert_expiry - time() < 10 * 24 * 3600
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "TLS cert expiring soon ({{ $labels.instance }})"
+            description: "The certificate served for {{ $labels.instance }} expires in less than 10 days."

--- a/services/operations/prometheus-blackbox-exporter/values.yaml
+++ b/services/operations/prometheus-blackbox-exporter/values.yaml
@@ -1,0 +1,57 @@
+fullnameOverride: prometheus-blackbox-exporter
+
+replicas: 1
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    memory: 64Mi
+
+# Default chart securityContext drops ALL caps; NET_RAW is required for the
+# icmp prober (external-dependency reachability to 1.1.1.1).
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+    add: ["NET_RAW"]
+
+config:
+  modules:
+    http_2xx:
+      prober: http
+      timeout: 5s
+      http:
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        method: GET
+        follow_redirects: true
+        preferred_ip_protocol: "ip4"
+    http_auth:
+      prober: http
+      timeout: 5s
+      http:
+        valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+        valid_status_codes: [200, 302, 401, 403]
+        method: GET
+        follow_redirects: false
+        preferred_ip_protocol: "ip4"
+    icmp:
+      prober: icmp
+      timeout: 5s
+      icmp:
+        preferred_ip_protocol: "ip4"
+    dns_cloudflare:
+      prober: dns
+      timeout: 5s
+      dns:
+        query_name: "cloudflare.com"
+        query_type: "A"
+        preferred_ip_protocol: "ip4"
+    tcp_connect:
+      prober: tcp
+      timeout: 5s

--- a/services/operations/stirling-pdf/app.yaml
+++ b/services/operations/stirling-pdf/app.yaml
@@ -10,3 +10,4 @@ ingress:
   port: 8080
   auth: true
   rateLimit: true
+  probe: true

--- a/services/operations/vaultwarden/app.yaml
+++ b/services/operations/vaultwarden/app.yaml
@@ -9,3 +9,4 @@ ingress:
   port: 8080
   auth: false
   rateLimit: true
+  probe: true

--- a/templates/ingress-chart/templates/_helpers.tpl
+++ b/templates/ingress-chart/templates/_helpers.tpl
@@ -1,0 +1,6 @@
+{{- define "ingress-chart.fqdn" -}}
+{{- $domainType := .Values.ingress.domainType | default "internal" -}}
+{{- $domain := index .Values.global.domains $domainType -}}
+{{- $host := .Values.ingress.host -}}
+{{- ternary $domain (printf "%s.%s" $host $domain) (eq $host "") -}}
+{{- end -}}

--- a/templates/ingress-chart/templates/ingressroute.yaml
+++ b/templates/ingress-chart/templates/ingressroute.yaml
@@ -1,9 +1,7 @@
 {{- if .Values.ingress.enabled }}
 {{- $domainType := .Values.ingress.domainType | default "internal" }}
-{{- $domain := index .Values.global.domains $domainType }}
 {{- $isInternal := eq $domainType "internal" }}
-{{- $host := .Values.ingress.host }}
-{{- $fqdn := ternary $domain (printf "%s.%s" $host $domain) (eq $host "") }}
+{{- $fqdn := include "ingress-chart.fqdn" . }}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:

--- a/templates/ingress-chart/templates/probe.yaml
+++ b/templates/ingress-chart/templates/probe.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.ingress.enabled .Values.ingress.probe }}
+{{- $fqdn := include "ingress-chart.fqdn" . }}
+{{- $module := ternary "http_auth" "http_2xx" (.Values.ingress.auth | default false) }}
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    release: kube-prometheus-stack
+spec:
+  interval: 60s
+  module: {{ $module }}
+  prober:
+    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - https://{{ $fqdn }}
+      labels:
+        service: {{ .Values.name }}
+        tier: ingress
+{{- end }}


### PR DESCRIPTION
## Summary
Adds in-cluster blackbox/synthetic monitoring and a curated set of PrometheusRules covering gaps the bundled `defaultRules` don't address. All rules route through the existing Alertmanager `ntfy` catch-all — no Alertmanager config change.

### Blackbox / synthetic
- New `prometheus-blackbox-exporter` app (chart 11.13.0) in `services/operations/`, namespace `monitoring`. Modules: `http_2xx`, `http_auth`, `icmp`, `dns_cloudflare`, `tcp_connect` (ICMP enabled via `NET_RAW`; memory-only limit).
- Static `Probe`s for external deps (`1.1.1.1` icmp/dns/https), the metrics-less ntfy adapter (`tcp_connect`), and infra UIs (Authentik, ArgoCD).
- Cascade opt-in `ingress.probe` flag (`templates/ingress-chart/templates/probe.yaml`) — reuses the ingress chart's computed FQDN via a new shared `_helpers.tpl` (`ingress-chart.fqdn`, also adopted by `ingressroute.yaml` with zero render change). Enabled on 12 curated services; any future service opts in with one line.

### Custom alert rules
- **cert-manager** (`manifests/templates/prometheus-rules.yaml`): cert not-ready (critical) / expiring-soon (warning, guarded against never-issued certs).
- **kube-prometheus-stack** (`manifests/custom-rules.yaml`): CronJob backup freshness (suspend-guarded), PVC low/critical floor, Alertmanager down. Deliberately excludes rules already covered by active `defaultRules` (`KubeJobFailed`, `AlertmanagerFailedToSendAlerts`).
- **blackbox** (`manifests/prometheus-rules.yaml`): probe failed (warning), external-dep down (critical), edge cert expiring soon.

## Validation
`helm template` (all flagged + unflagged services), `kubeconform` (10/10 valid), and `pre-commit` all pass locally. The `_helpers.tpl` refactor was proven to produce byte-identical `ingressroute.yaml` output across all 42 ingress services.

## Post-merge verification (after ArgoCD sync)
- Blackbox pod Running; `Probe` targets appear under Prometheus `/targets` as `probe/...`; `probe_success == 1` for healthy targets; new rule groups under `/rules`.
- One-time check of listmonk's root-path HTTP status (its SPA may serve non-2xx on `/`); switch module/path if it false-fails.