### PR TITLE
style(homepage-admin): merge the two status dots into one

### DIFF
--- a/services/operations/homepage-admin/manifests/templates/configmap.yaml
+++ b/services/operations/homepage-admin/manifests/templates/configmap.yaml
@@ -35,6 +35,19 @@ data:
     li.service[data-name="Calendar"] .service-title {
       display: none;
     }
+
+    /* Merge the site-monitor and Kubernetes dots into a single indicator.
+       The site-monitor dot is hidden but stays mounted and polling, so its
+       result is folded into the clickable Kubernetes dot below. */
+    .service-tags:has(.k8s-status) .service-site-monitor {
+      display: none;
+    }
+
+    /* A failing HTTP check turns the surviving dot red (Tailwind rose-500),
+       overriding the green/orange pod status. */
+    .service-tags:has(.site-monitor-status .bg-rose-500) .k8s-status > div {
+      background-color: rgb(244 63 94);
+    }
   kubernetes.yaml: |
     mode: cluster
   settings.yaml: |


### PR DESCRIPTION
Every service that has a `siteMonitor` also has an `app:` selector (55 of them), so each tile was rendering two adjacent dots that almost always agreed with each other.

## Approach

Three lines of `custom.css` — no changes to any service definition:

- `.service-tags:has(.k8s-status) .service-site-monitor { display: none }` hides the duplicate. `display: none` does not unmount the React component, so it keeps polling.
- `.service-tags:has(.site-monitor-status .bg-rose-500) .k8s-status > div` repaints the surviving dot red when the HTTP check fails.

The `:has(.k8s-status)` guard means a service without a Kubernetes selector would keep its own dot. (Today there are none — but it keeps the rule safe.)

Resulting semantics for the single dot:

| Pod | HTTP | Dot |
|---|---|---|
| Running | 2xx/3xx | green |
| Running | failing | **red** |
| down / partial / not found | any | orange |

## Verification

Checked against the live dashboard with a headless browser rather than by inspection:

- visible site-monitor dots **7 → 0**; Kubernetes dots unchanged at **10**
- healthy dot stays `oklch(0.696 0.17 162.48)` (emerald-500)
- simulating a failed HTTP check repaints the remaining dot `rgb(244, 63, 94)` (rose-500)

`yamllint`, `prettier` and `check-homepage-coverage.py` all pass.

## Trade-off

The site-monitor's `title` tooltip (`HTTP status 200 (10 ms)`) is no longer reachable; the surviving dot shows the pod status tooltip. The household dashboard has no `app:` selectors, so it is unaffected.