### PR TITLE
feat(system): deploy Stakater Reloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ infrastructure/
 │   ├── metallb              L2 load balancer (multiple IP pools)
 │   ├── intel-device-operator GPU scheduling (SR-IOV virtual functions)
 │   ├── crowdsec             Intrusion detection with mTLS
+│   ├── reloader             Restarts workloads on ConfigMap/Secret change
 │   └── prometheus-crds      Phase 1 — CRD-only (no Prometheus yet)
 │
 ├── controllers/         Phase 3 (Controllers)

--- a/bootstrap/appsets/cluster-apps.yaml
+++ b/bootstrap/appsets/cluster-apps.yaml
@@ -105,6 +105,11 @@ spec:
           jqPathExpressions:
             - '.spec.template.metadata.annotations["checksum/lapi-secret"]'
             - '.spec.template.metadata.annotations["checksum/lapi-configmap"]'
+            # Stakater Reloader stamps this on restart; without ignoring it,
+            # selfHeal strips it and Reloader re-adds it, forever.
+            # Only Deployments opt in today — add StatefulSet/DaemonSet blocks
+            # if a workload of those kinds ever gets reloader.stakater.com/auto.
+            - '.spec.template.metadata.annotations["reloader.stakater.com/last-reloaded-from"]'
   templatePatch: |
     {{- $repo := "https://github.com/Starktastic-Homelab/apps.git" }}
     {{- $isService := eq .category "services" }}

--- a/infrastructure/system/reloader/app.yaml
+++ b/infrastructure/system/reloader/app.yaml
@@ -1,0 +1,7 @@
+name: reloader
+namespace: kube-system
+deployPhase: controllers
+chart:
+  repo: https://stakater.github.io/stakater-charts
+  name: reloader
+  version: 2.2.16

--- a/infrastructure/system/reloader/values.yaml
+++ b/infrastructure/system/reloader/values.yaml
@@ -1,0 +1,21 @@
+reloader:
+  # GitOps-safe strategy: stamps a pod-template annotation instead of injecting
+  # STAKATER_* env vars into the workload spec. The annotation is excluded from
+  # diffing in bootstrap/appsets/cluster-apps.yaml, so Argo's selfHeal doesn't
+  # fight Reloader over every restart.
+  reloadStrategy: annotations
+
+  # Opt-in only: workloads must carry reloader.stakater.com/auto: "true".
+  autoReloadAll: false
+
+  # ServiceMonitor is deprecated upstream in favour of PodMonitor.
+  podMonitor:
+    enabled: true
+
+  deployment:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi


### PR DESCRIPTION
Deploys [stakater/reloader](https://github.com/stakater/reloader) so workloads restart automatically when a mounted ConfigMap or Secret changes. The `reloader.stakater.com/auto: "true"` annotation already on ntfy has been a no-op until now.

| File | Change |
|------|--------|
| `infrastructure/system/reloader/app.yaml` | chart `2.2.16`, `kube-system`, `deployPhase: controllers` |
| `infrastructure/system/reloader/values.yaml` | `reloadStrategy: annotations`, PodMonitor on, small resource requests |
| `bootstrap/appsets/cluster-apps.yaml` | one extra `jqPathExpression` ignoring the annotation Reloader stamps |
| `README.md` | one tree line |

### Why the annotations strategy

The chart's default `env-vars` strategy injects `STAKATER_*` env vars into the workload spec. Argo's `selfHeal` would revert that, Reloader would re-apply it, and the two would fight in a loop. The `annotations` strategy stamps `reloader.stakater.com/last-reloaded-from` on the pod template instead, which is a single line to exclude from diffing — upstream recommends it for GitOps.

### Verification

- `helm template` through the repo's `globals.yaml` -> `values.yaml` cascade renders `--reload-strategy=annotations` and the PodMonitor
- `yamllint` clean, ApplicationSet still parses

### Deliberately skipped

- StatefulSet/DaemonSet `ignoreDifferences` blocks — nothing of those kinds is annotated yet
- ServiceMonitor — deprecated upstream in favour of PodMonitor
- HA replicas — add when one proves insufficient