### PR TITLE
fix(karakeep): pull chrome sidecar from Docker Hub instead of dead GCR mirror

### DIFF
--- a/services/operations/karakeep/values.yaml
+++ b/services/operations/karakeep/values.yaml
@@ -42,7 +42,8 @@ controllers:
               periodSeconds: 5
       chrome:
         image:
-          repository: gcr.io/zenika-hub/alpine-chrome
+          # ponytail: gcr.io/zenika-hub mirror returns 403 (GCR retired); Docker Hub has the same digest
+          repository: zenika/alpine-chrome
           tag: "124@sha256:1a0046448e0bb6c275c88f86e01faf0de62b02ec8572901256ada0a8c08be23f"
         args:
           - --no-sandbox


### PR DESCRIPTION
## Problem

`karakeep`'s `chrome` sidecar has been stuck in `ImagePullBackOff`:

```
Failed to pull image "gcr.io/zenika-hub/alpine-chrome:124@sha256:1a0046...":
failed to authorize: failed to fetch anonymous token: unexpected status from
GET request to https://gcr.io/v2/token?scope=repository%3Azenika-hub%2Falpine-chrome%3Apull&service=gcr.io: 403 Forbidden
```

The `zenika-hub` GCR mirror has been retired — `gcr.io` returns **403** even for a plain anonymous token request, so this is not a cluster-side auth or network problem and it will not recover on its own.

## Fix

Point the sidecar at Docker Hub, which serves the **identical manifest**. Only the registry changes; the pinned digest `sha256:1a0046...` is byte-identical and left untouched, so the running image is unchanged.

Confirmed the existing digest resolves on Docker Hub before switching:

```
GET registry-1.docker.io/v2/zenika/alpine-chrome/manifests/sha256:1a0046... → 200
```

## Verification

Pulled the new reference on `kube-master-01`:

```
application/vnd.oci.image.index.v1+json sha256:1a0046448e0bb6c275c88f86e01faf0de62b02ec8572901256ada0a8c08be23f
Completed pull from OCI Registry (docker.io/zenika/alpine-chrome@sha256:1a0046...)  elapsed: 9.1 s  total: 268.6 (29.6 MiB/s)
```

Test image was removed from the node afterwards. `yamllint -c .github/yamllint.yaml` passes on the changed file.

## Context

Found while investigating a suspected k3s outage after the SR-IOV driver update and VM rebuild. The cluster itself was fine — it rode out a cold-start image-pull storm that starved etcd and self-healed (121/123 pods). This `karakeep` failure was the one genuine, pre-existing issue, unrelated to the rebuild.