### PR TITLE
feat(media): add Cleanuparr to sweep unimportable Sonarr queue items

### DIFF
--- a/services/media/cleanuparr/app.yaml
+++ b/services/media/cleanuparr/app.yaml
@@ -1,0 +1,11 @@
+name: cleanuparr
+namespace: media
+deployPhase: services
+
+ingress:
+  enabled: true
+  host: cleanuparr
+  domainType: "internal"
+  port: 11011
+  auth: true
+  rateLimit: true

--- a/services/media/cleanuparr/values.yaml
+++ b/services/media/cleanuparr/values.yaml
@@ -1,0 +1,42 @@
+# Cleanuparr sweeps *arr queue items that can never import. Sonarr keeps
+# completed-but-rejected downloads in the queue forever (removeCompletedDownloads
+# only fires after a successful import), and autobrr's push grabs regularly
+# produce them: the release *title* is scored at grab time, the *filenames*
+# inside the torrent are scored at import time, and the two disagree.
+#
+# Config lives in a SQLite DB under /config and is set through the web UI, so
+# there is no ConfigMap here. Only the Queue Cleaner is intended to be enabled —
+# qbit-manage already owns share limits and orphan/noHL removal, so Cleanuparr's
+# Download Cleaner is deliberately left off and /data is not mounted.
+controllers:
+  main:
+    containers:
+      main:
+        image:
+          repository: ghcr.io/cleanuparr/cleanuparr
+          tag: 2.10.5@sha256:c7cd53ad559a67147637de3d825f66ef6e6a5498490b73f49c6e4d72f13bed76
+        env:
+          PORT: "11011"
+        probes:
+          liveness:
+            enabled: true
+            type: HTTP
+            path: /health
+            port: 11011
+          readiness:
+            enabled: true
+            type: HTTP
+            path: /health
+            port: 11011
+          startup:
+            enabled: true
+            type: HTTP
+            path: /health
+            port: 11011
+
+service:
+  main:
+    controller: main
+    ports:
+      http:
+        port: 11011

--- a/services/operations/homepage-admin/manifests/templates/configmap.yaml
+++ b/services/operations/homepage-admin/manifests/templates/configmap.yaml
@@ -907,6 +907,13 @@ data:
               type: autobrr
               url: http://autobrr.media.svc.cluster.local:7474
               key: {{ "{{" }}HOMEPAGE_VAR_AUTOBRR_KEY{{ "}}" }}
+        - Cleanuparr:
+            icon: cleanuparr.png
+            href: https://cleanuparr.internal.starktastic.net
+            description: Stuck queue cleanup
+            siteMonitor: http://cleanuparr.media.svc.cluster.local:11011/health
+            namespace: media
+            app: cleanuparr
         - qBittorrent:
             icon: qbittorrent.png
             href: https://qbittorrent.internal.starktastic.net


### PR DESCRIPTION
## Problem

Sonarr's main instance had accumulated **32 queue rows (10 torrents)** that could never import — all `completed` with `importBlocked`/`importPending`. Sonarr never drops these on its own: `removeCompletedDownloads` only fires after a *successful* import, so completed-but-rejected downloads sit in the queue forever.

## Root cause

All 10 were grabbed via `releaseSource=ReleasePush` — **autobrr**, not Sonarr's own RSS/search. Two failure modes, both inherent to push-based grabbing:

**1. Title-vs-filename custom format mismatch.** X-Men '97 S02 was pushed as `X-Men '97 S02 2160p DSNP WEB-DL DD+ 5.1 Atmos DV HDR10+ H.265-FLUX` → scored **6460** vs the existing files' 6450 → grab approved. The files *inside* the torrent are named `...DV.HDR.H.265` (no `HDR10+`) → miss the `HDR10+ Boost` CF → rescore to **6360** at import, below the existing files. All 9 episodes rejected. House of the Dragon S03 failed identically.

**2. Announce race.** autobrr pushes at age ~0.03 min, so several candidates for one episode land minutes apart. First to import wins; losers stick as `Episode file already imported` / `Not an upgrade`.

Neither is fixable with a Sonarr setting — grab scores the *release title*, import scores the *file*. Recyclarr's `HDR10+ Boost` CF is correct, and autobrr racing is the point of autobrr. The residue is the cost; something has to sweep it.

## Change

Adds Cleanuparr (`ghcr.io/cleanuparr/cleanuparr:2.10.5`) as a media service, plus its homepage-admin entry.

Deliberate scoping:

- **Queue Cleaner only.** qbit-manage already owns share limits and orphan/`noHL` removal, so Cleanuparr's Download Cleaner is left off and `/data` is **not** mounted — two tools racing to delete the same torrents is worse than the problem being solved.
- **`removeFromClient=false` is mandatory** when configuring the Queue Cleaner. Every affected indexer here is a private tracker (LST, Aither, DarkPeers, IPTorrents, TorrentLeech, AlphaRatio, FileList, Luminarr) and the torrents are still seeding.
- No ConfigMap — Cleanuparr stores config in SQLite under `/config` and is set up through the web UI.
- Ingress is internal + Authentik, matching the other *arr admin UIs.

## Post-merge

Cleanuparr needs one-time UI setup at `https://cleanuparr.internal.starktastic.net`: add the Sonarr/Radarr/Lidarr instances and qBittorrent, then enable **Queue Cleaner** with failed-import handling and `removeFromClient` off.

## Validation

- The live queue was already cleared manually: **32 → 0**, with all 10 torrents verified still present in qBittorrent and seeding.
- `helm template` renders cleanly for both the app-template chart and the ingress chart.
- `scripts/check-homepage-coverage.py` → `Homepage coverage OK: 48 hosts, both dashboards consistent`.
- `pre-commit run` on all changed files → all hooks pass.
- radarr / radarr-ru / sonarr-ru / lidarr queues were all 0, so this was Sonarr-only.