### PR TITLE
fix(qbit-manage): count cross-seed hardlinks so noHL detection is correct

### DIFF
--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -114,3 +114,8 @@ data:
         - "**/.DS_Store"
         - "**/*.!qB"
         - "**/incomplete/**"
+        # Read-only re-mount of /data/cross-seed-links so the hardlink check
+        # counts those links (see qbit-manage values.yaml). qBittorrent reports
+        # these torrents under /data/cross-seed-links, so the paths never match
+        # what the orphan scan sees and every one would look untracked.
+        - "**/.cross-seed-links/**"

--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -86,6 +86,10 @@ data:
       movies:
       tv:
       music:
+      # Safe only because the cross-seed link dir is re-mounted inside root_dir (see
+      # values.yaml): nlink - inode_count then equals the number of *library* links, so a
+      # cross-seed whose content is still in the library can never be tagged noHL.
+      cross-seed:
 
     share_limits:
       noHL:

--- a/services/media/qbit-manage/values.yaml
+++ b/services/media/qbit-manage/values.yaml
@@ -52,3 +52,24 @@ persistence:
             readOnly: true
   media:
     enabled: true
+  # cross-seed hardlinks its matches into /data/cross-seed-links, which sits
+  # OUTSIDE root_dir (/data/torrents). qbit-manage decides "no hardlinks" with
+  # `st_nlink - (links found under root_dir) > 0`, and it only walks root_dir,
+  # orphaned_dir and recycle_bin — there is no option to exclude an outside
+  # directory (checked through v4.11.0: nohardlinks accepts only `exclude_tags`
+  # and `ignore_root_dir`). So a cross-seed link alone makes a torrent look like
+  # it is in the library, and it is grouped as seed-forever instead of noHL.
+  #
+  # Re-mounting the same subdirectory inside root_dir puts those links where the
+  # existing `ignore_root_dir: true` default already looks, so they get counted
+  # and subtracted. Read-only because nothing here should ever write to it, and
+  # `**/.cross-seed-links/**` is excluded in orphaned.exclude_patterns so the
+  # orphan scan does not treat them as untracked (qBittorrent reports these
+  # torrents under /data/cross-seed-links, so the paths would not match).
+  cross-seed-links:
+    enabled: true
+    existingClaim: media-library-pvc
+    globalMounts:
+      - path: /data/torrents/.cross-seed-links
+        subPath: cross-seed-links
+        readOnly: true


### PR DESCRIPTION
## Problem

cross-seed hardlinks its matches into `/data/cross-seed-links`, which sits **outside** qbit-manage's `root_dir` (`/data/torrents`).

qbit-manage decides "no hardlinks" with:

```python
# modules/util.py
return file_stat.st_nlink - self.inode_count.get(file_stat.st_ino, 1) > 0
```

…and builds `inode_count` by walking **only** `root_dir`, `orphaned_dir` and `recycle_bin`. So a cross-seed link is indistinguishable from a library hardlink, and any torrent cross-seed matched looks imported even when the *arr never imported it.

Confirmed live — `Lucky.2026.S01E06...FLUX.mkv`, which Sonarr rejected as "not an upgrade" and never imported:

```
nlink=2
  /data/torrents/tv/Lucky.2026.S01E06...FLUX.mkv          (the torrent)
  /data/cross-seed-links/LST/Lucky.2026.S01E06...FLUX.mkv  (cross-seed)
  /data/library      → 0 links
  /data/library-ru   → 0 links
```

`2 - 1 = 1 > 0` → "has hardlinks" → no `noHL` tag → grouped `~share_limit_999.default` (`max_ratio: -1`, `cleanup: false`, seed forever) instead of `~share_limit_1.noHL`.

## Why a mount and not a setting

There is no config option for this. `nohardlinks` accepts only `exclude_tags` and `ignore_root_dir` — verified against `web-ui/js/config-schemas/nohardlinks.js` on latest **v4.11.0**, not just our v4.8.1. `ignore_root_dir` (default `true`) ignores links *inside* `root_dir`, which is the opposite of what's needed.

So the same subdirectory is re-mounted read-only at `/data/torrents/.cross-seed-links`. That puts the links where `ignore_root_dir` already looks, so they get counted and subtracted — **no code change, no file movement, and no re-pointing of the 3545 cross-seed torrents** (the alternative, relocating cross-seed's `linkDirs`, would need `setLocation` on every one of them).

The orphan scan needs a matching exclusion: `orphaned_files = root_files - torrent_files`, and qBittorrent reports these torrents under `/data/cross-seed-links`, so via the new path every file would look untracked and be moved to `.orphaned`. Hence `**/.cross-seed-links/**` in `orphaned.exclude_patterns`, plus `readOnly: true` as a second belt.

## Validation

Simulated against the live client, mirroring qbit-manage's real largest-file rule:

| | |
|---|---|
| unchanged verdict | 633 |
| **newly `noHL`** | **218 (7.28 TB)** |
| lost `noHL` tag | **0** |
| newly `noHL` but actually in the library | **0** (checked against 17403 library inodes) |

Also verified:
- Nested PVC `subPath` mount works, and resolves to the **same inode** from both paths.
- Works in the order Helm renders it (nested mount listed before `/data`) — tested explicitly.
- `**/.cross-seed-links/**` matches under `fnmatch` and does not match normal torrent paths.
- `helm template` renders for both qbit-manage and qbit-manage-ru (which inherits this via `baseApp`; it currently has 0 torrents, so no effect).
- `pre-commit run` on both changed files → all hooks pass.

## ⚠️ Read before merging

**This is a correctness fix, not a space reclaim.** 217 of the 218 are pinned by an active cross-seed sibling holding the same inodes, and those siblings are themselves `~share_limit_999.default` (seed forever). Removing all 218 frees **~0.08 TB**, not 7.28 TB. Reclaiming the rest needs a `share_limits` group for the `cross-seed` category — a separate policy decision.

**Blast radius:** the 218 move into the `noHL` group (`max_ratio: 10`, `max_seeding_time: 30d`, `cleanup: true`). Many are long past 30 days, so the first run after this deploys will remove a large batch at once. Their data survives via the cross-seed siblings, but they stop seeding on their original tracker. Suggest one run with `dry_run: true` to review the list first.