### PR TITLE
fix(appsets): add ApplicationSet-level diff-preview watch-pattern

### DIFF
--- a/bootstrap/appsets/cluster-apps.yaml
+++ b/bootstrap/appsets/cluster-apps.yaml
@@ -3,6 +3,12 @@ kind: ApplicationSet
 metadata:
   name: cluster-apps
   namespace: argocd
+  annotations:
+    # See config-apps.yaml: argocd-diff-preview filters ApplicationSets by their OWN
+    # metadata.annotations *before* expanding them, so this coarse gate is required
+    # in addition to the per-Application pattern in spec.template below.
+    # Keep it as the union of the patterns spec.template can render.
+    argocd-diff-preview/watch-pattern: '^infrastructure/.*, ^services/.*, ^templates/.*'
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
@@ -66,7 +72,9 @@ spec:
       annotations:
         notifications.argoproj.io/subscribe.on-sync-failed.ntfy: ""
         notifications.argoproj.io/subscribe.on-health-degraded.ntfy: ""
-        argocd-diff-preview/watch-pattern: '{{.path.path}}/.*, templates/.*'
+        # Anchored: unanchored 'templates/.*' also matches every app's own
+        # manifests/templates/ dir, which selected all 74 apps on any such PR.
+        argocd-diff-preview/watch-pattern: '^{{.path.path}}/.*, ^templates/.*'
     spec:
       project: default
       sources: []

--- a/bootstrap/appsets/config-apps.yaml
+++ b/bootstrap/appsets/config-apps.yaml
@@ -3,6 +3,13 @@ kind: ApplicationSet
 metadata:
   name: config-apps
   namespace: argocd
+  annotations:
+    # argocd-diff-preview filters ApplicationSets by their OWN metadata.annotations
+    # *before* expanding them into Applications, so this coarse gate is required in
+    # addition to the per-Application pattern in spec.template below. Without it the
+    # appset is skipped and every PR reports an empty diff.
+    # Keep it as the union of the patterns spec.template can render.
+    argocd-diff-preview/watch-pattern: '^infrastructure/base-configs/.*, ^infrastructure/configs/.*, ^templates/globals\.yaml'
 spec:
   goTemplate: true
   goTemplateOptions: ["missingkey=error"]
@@ -39,7 +46,7 @@ spec:
       annotations:
         notifications.argoproj.io/subscribe.on-sync-failed.ntfy: ""
         notifications.argoproj.io/subscribe.on-health-degraded.ntfy: ""
-        argocd-diff-preview/watch-pattern: "{{.path}}/.*, templates/globals.yaml"
+        argocd-diff-preview/watch-pattern: '^{{.path}}/.*, ^templates/globals\.yaml'
     spec:
       project: default
       sources:

--- a/services/operations/pairdrop/values.yaml
+++ b/services/operations/pairdrop/values.yaml
@@ -7,7 +7,7 @@ controllers:
           tag: 1.11.2@sha256:db0b99532f262410d4ca932d61eec248e4b6756a05f1516546f4b7baa96f1594
         env:
           WS_FALLBACK: "true"
-          RATE_LIMIT: "true"
+          RATE_LIMIT: "false"
         probes:
           liveness:
             enabled: true

--- a/services/operations/pairdrop/values.yaml
+++ b/services/operations/pairdrop/values.yaml
@@ -7,7 +7,7 @@ controllers:
           tag: 1.11.2@sha256:db0b99532f262410d4ca932d61eec248e4b6756a05f1516546f4b7baa96f1594
         env:
           WS_FALLBACK: "true"
-          RATE_LIMIT: "false"
+          RATE_LIMIT: "true"
         probes:
           liveness:
             enabled: true


### PR DESCRIPTION
## Problem

The **ArgoCD diff preview** job has been passing green while verifying nothing. Every recent PR (#1052–#1062) got the same comment:

> Found no changed Applications that watched these files: ...

## Root cause

`argocd-diff-preview` filters ApplicationSets by their **own** `metadata.annotations` *before* expanding them into Applications:

- `cmd/main.go` runs `ApplicationSelection` **before** `ConvertAppSetsToAppsInBothBranches`
- `pkg/argoapplication/filter.go:235` reads `metadata.annotations` off the raw resource

Both appsets only had `argocd-diff-preview/watch-pattern` on `spec.template.metadata.annotations`. With `WATCH_IF_NO_WATCH_PATTERN_FOUND=false`, both were silently skipped — the tool exited before even creating a cluster:

```
🤖 Which resulted in 2 Argo CD Applications or ApplicationSets (branch: main)
🤖 Selected 0 Application[Sets], Skipped 2 Application[Sets] (branch: main)
👀 Found no applications to process in either branch
✨ Total execution time: 0s
```

The tool's docs require the annotation in **two** places: a coarse gate on the ApplicationSet, and the per-Application pattern on the template.

## Fix

- Add the coarse `watch-pattern` gate to `metadata.annotations` on both appsets, as the union of what `spec.template` can render.
- Anchor all patterns with `^`. Unanchored `templates/.*` also matched every app's own `manifests/templates/` dir, which would have selected all 74 apps on any such PR.

## Verification

Replaying PR #1062's changed files through the tool's matching logic: **2** Applications selected (`infra-configs`, `homepage-admin`) — previously 0, and 74 without the anchors. Docs-only PRs still fast-exit with no cluster.

This PR touches the appsets themselves, so generated apps inherit the appset `FileName` (`application_sets.go:339`) and **all** apps render — the comment below is the end-to-end proof.