### PR TITLE
fix(ci): blank line after </details> in validation report

### DIFF
--- a/.github/workflows/validate-and-diff.yml
+++ b/.github/workflows/validate-and-diff.yml
@@ -99,6 +99,9 @@ jobs:
             echo '```' >> validation-report.md
             echo "" >> validation-report.md
             echo "</details>" >> validation-report.md
+            # Required: GitHub keeps parsing raw HTML until a blank line, so
+            # without this the next status line renders its **bold** literally.
+            echo "" >> validation-report.md
           fi
 
           if [ "${{ steps.kubeconform.outputs.exit_code }}" = "0" ]; then
@@ -112,6 +115,7 @@ jobs:
              echo '```' >> validation-report.md
              echo "" >> validation-report.md
              echo "</details>" >> validation-report.md
+             echo "" >> validation-report.md
           else
              echo "❌ **Kubeconform:** FAILED" >> validation-report.md
              echo "" >> validation-report.md
@@ -123,6 +127,7 @@ jobs:
              echo '```' >> validation-report.md
              echo "" >> validation-report.md
              echo "</details>" >> validation-report.md
+             echo "" >> validation-report.md
           fi
 
           if [ "${{ steps.homepage.outputs.exit_code }}" = "0" ]; then
@@ -138,6 +143,7 @@ jobs:
             echo '```' >> validation-report.md
             echo "" >> validation-report.md
             echo "</details>" >> validation-report.md
+            echo "" >> validation-report.md
           fi
 
           echo "" >> validation-report.md


### PR DESCRIPTION
## Symptom

`✅ **Homepage Coverage:** Passed` renders with literal double-asterisks, while YAML Lint and Kubeconform above it render bold.

## Root cause

`</details>` starts a Markdown *HTML block*, which only terminates at a blank line. The Homepage status line was emitted directly after `</details>`, so it stayed inside the raw-HTML block and was never Markdown-processed.

Verified against GitHub's own GFM API (`gh api /markdown -f mode=gfm`):

| input | output |
|---|---|
| `</details>` + text | `✅ **No blank line:** Passed` (literal) |
| `</details>` + blank + text | `<p>✅ <strong>With blank line:</strong> Passed</p>` |

## Broader than reported

Three of the four `</details>` blocks lacked the blank line. When **YAML Lint fails**, the *Kubeconform* line breaks identically — it just hadn't been seen because yamllint has been passing.

## Verification

Replayed the actual `Create validation report` script for all 8 pass/fail combinations and rendered each through `/markdown`:

- before: **8 / 8 failing**
- after: **0 / 8 failing**, every status line emits `<strong>`

All four blocks now self-terminate, so a section added later can't reintroduce this.