### PR TITLE
feat(home-assistant): public ingress for Yandex Smart Home direct connection

### DIFF
--- a/scripts/check-homepage-coverage.py
+++ b/scripts/check-homepage-coverage.py
@@ -39,8 +39,12 @@ DASHBOARDS = {
     "user": "services/operations/homepage/manifests",
 }
 
-# Neither dashboard lists itself as a service.
-EXCLUDED_HOSTS = {"starktastic.net", "admin.starktastic.net"}
+# Neither dashboard lists itself as a service. ha.starktastic.net is a
+# machine-only alias: it exists so Yandex Smart Home can reach Home Assistant's
+# OAuth and API endpoints, and Home Assistant itself is already listed on the
+# admin dashboard under ha.internal.starktastic.net, so nothing is reachable
+# but invisible.
+EXCLUDED_HOSTS = {"starktastic.net", "admin.starktastic.net", "ha.starktastic.net"}
 
 HOST_RE = re.compile(r"Host\(`([^`]+)`\)")
 VAR_RE = re.compile(r"\{\{HOMEPAGE_VAR_[A-Z0-9_]+\}\}")

--- a/services/home-automation/home-assistant/manifests/ingressroute.yaml
+++ b/services/home-automation/home-assistant/manifests/ingressroute.yaml
@@ -1,0 +1,41 @@
+# Public route for the Yandex Smart Home (Alice) direct connection.
+# The ingress-chart emits exactly one IngressRoute per app, and home-assistant
+# already spends it on the internal host (`ha.internal.starktastic.net` on the
+# websec-int entrypoint / 10.9.9.90). The public VIP is a different entrypoint,
+# so the second hostname has to be a standalone manifest — same pattern as
+# navidrome and microbin.
+#
+# Whole-host route on purpose: the Yandex OAuth flow needs /auth/authorize,
+# /auth/token, the login page and its static assets, not just
+# /api/yandex_smart_home.
+#
+# ponytail: no dedicated Certificate — the default TLSStore already serves the
+# `*.starktastic.net` wildcard from starktastic-net-cert (traefik-system).
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: home-assistant-public
+  namespace: home-automation
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    # Bare Host() already matches every path; no PathPrefix, no rewrites, no
+    # StripPrefix. Traefik passes Host through and sets X-Forwarded-Proto=https
+    # and X-Forwarded-For itself, which is what HA's trusted_proxies expects.
+    - match: Host(`ha.starktastic.net`)
+      kind: Rule
+      services:
+        - name: home-assistant-main
+          port: 8123
+      middlewares:
+        # Same bouncer every other public route carries. No authentik-middleware
+        # here: forward-auth would break the Yandex OAuth callback. No
+        # rate-limit-strong either — app.yaml keeps rateLimit false for HA, and
+        # its frontend is request-heavy over the websocket.
+        - name: crowdsec-bouncer
+          namespace: traefik-system
+  tls:
+    store:
+      name: default
+      namespace: traefik-system


### PR DESCRIPTION
Adds `ha.starktastic.net` so Yandex Smart Home (Alice) can reach Home Assistant directly, without Yaha Cloud.

## What changed

Two files:

| File | Change |
|---|---|
| `services/home-automation/home-assistant/manifests/ingressroute.yaml` | new — public IngressRoute |
| `scripts/check-homepage-coverage.py` | +6/−2 — exclude the machine-only alias |

The ingress-chart emits exactly **one** IngressRoute per app, and home-assistant already spends it on `ha.internal.starktastic.net` (`websec-int` / 10.9.9.90). The public VIP is a different entrypoint, so the second hostname has to be a standalone manifest — the same pattern navidrome and microbin already use. **The internal route is untouched** (`helm template` renders it byte-identical to what is live).

Whole-host route on purpose: the OAuth flow needs `/auth/authorize`, `/auth/token` and the login assets, not just `/api/yandex_smart_home`. No `authentik-middleware`, because forward-auth would break the Yandex callback; `crowdsec-bouncer` is kept, as on every other public route. No rate limit, matching `rateLimit: false` in `app.yaml`.

## What deliberately did *not* change

Verified rather than assumed:

- **TLS** — `starktastic-net-cert` already covers `*.starktastic.net` and is the default cert of TLSStore `default`. No new Certificate.
- **DNS** — Cloudflare already has a wildcard: `ha.starktastic.net` → `starktastic.net` → `A 62.56.245.187`, DNS-only, **no AAAA**. Not managed as code in this repo, so no IaC change.
- **Proxy trust** — HA 2026.6.4 already has `use_x_forwarded_for: true` with `trusted_proxies: [10.42.0.0/16, 10.9.9.0/24]`, covering both the Traefik pod CIDR and the SNAT'd node IP. The public route reuses the same pods and the same Service as the internal one, so this is already proven by the internal route working today.
- **NetworkPolicy** — none exist in the cluster, so none added.

## Security

`ha.starktastic.net` is reachable from the internet — unavoidable, since Yandex OAuth needs the login and authorize endpoints. It is **not** open access to the dashboard:

Traefik has no `forwardedHeaders.trustedIPs` on any entrypoint, so it strips client-supplied `X-Forwarded-For` and substitutes the real client IP. That IP is not in the `openid` component's `trusted_ips`, so `block_login` engages: `/auth/authorize` redirects to Authentik and `POST /auth/login_flow` returns an empty stub. **Internet visitors get Authentik SSO; the local password form is dead from outside.** LAN users are unaffected.

Tested: spoofing `X-Forwarded-For: 8.8.8.8` through Traefik changed nothing (200, identical to baseline, no HA error log). The same spoof sent directly to HA *did* change behaviour (400, `Received X-Forwarded-For header from an untrusted proxy`) — so the test discriminates, and Traefik is what neutralises it.

⚠️ Follow-up worth tracking: `block_login` is enforced by a custom component monkey-patching aiohttp router internals, so an HA upgrade could silently break it. Re-check after each upgrade:

```bash
curl -s -X POST https://ha.starktastic.net/auth/login_flow \
  -H 'Content-Type: application/json' \
  -d '{"client_id":"https://ha.starktastic.net/","handler":["homeassistant",null],"redirect_uri":"https://ha.starktastic.net/"}' \
  | grep -o '"block_login":[^,}]*'   # must be true
```

## Validation

```
yamllint .                      exit 0
kubeconform (CI cmd)            86 resources / 80 files — Valid: 85, Invalid: 0, Errors: 0
check-homepage-coverage.py      OK: 48 hosts, both dashboards consistent (unchanged)
prettier@3.9.6 --check          passes
kubectl apply --dry-run=client  created (dry run)
helm template ingress-chart     internal route byte-identical to live
```

Also confirmed live: `crowdsec-bouncer` and TLSStore `default` exist, and no other IngressRoute claims the host.

## Post-merge checks

```bash
dig +short ha.starktastic.net @1.1.1.1
dig +short ha.starktastic.net AAAA @1.1.1.1                                   # must be empty
curl -sSo /dev/null -w '%{http_code}\n' https://ha.starktastic.net/manifest.json   # 200, from off-LAN
curl -sSI https://ha.internal.starktastic.net | head -1                        # unchanged
kubectl -n home-automation logs deploy/home-assistant --since=10m | grep -Ei 'untrusted|redirect'
curl -sSo /dev/null -w '%{http_code}\n' https://ha.starktastic.net/api/yandex_smart_home/v1.0/ping  # 404 until HACS install
```

## Manual steps after merge

1. HA → Settings → System → Network: Internal `https://ha.internal.starktastic.net`, External `https://ha.starktastic.net`. Both are currently unset and UI-owned (no `homeassistant:` block exists), so this cannot be done in Git.
2. HACS → Yandex Smart Home → **Direct connection**.
3. Expose one test light via an `Expose to Yandex` label; create a dedicated non-admin HA account for Yandex.
4. Yandex private skill — Backend `https://ha.starktastic.net/api/yandex_smart_home`, App ID `https://social.yandex.net/`, Auth `https://ha.starktastic.net/auth/authorize`, Token & Refresh `https://ha.starktastic.net/auth/token`. Keep the skill secret out of Git (`scripts/seal.sh` if it ever needs to live here).

Note: on HA **2026.8+** the YAML `http:` block must be migrated via Settings → System → Network. This cluster is on 2026.6.4, so it is correct as-is — do not delete it before importing through the UI.

Rollback: revert this PR, or `kubectl -n home-automation delete ingressroute home-assistant-public`. Nothing else is touched.
