### PR TITLE
fix(dns): use service.namespace instead of .svc.cluster.local FQDNs

### DIFF
--- a/.github/workflows/validate-and-diff.yml
+++ b/.github/workflows/validate-and-diff.yml
@@ -80,6 +80,21 @@ jobs:
           cat homepage.txt
           if [ $EXIT_CODE -ne 0 ]; then echo "❌ Homepage Coverage Failed"; else echo "✅ Homepage Coverage Passed"; fi
 
+      # ponytail: plain grep, no script. Pods run with ndots:5, so a 4-dot name like
+      # svc.ns.svc.cluster.local tries every search suffix — including the node's
+      # mgmt.arpa — before the absolute name, leaking one upstream query per lookup.
+      # `service` (same ns) or `service.namespace` (cross ns) hit on attempt 1 or 2.
+      - name: No cluster.local FQDNs
+        run: |
+          hits=$(git grep -n 'svc\.cluster\.local' -- . ':!docs' ':!.github' \
+            | grep -v 'crowdsecLapiHost\|https://argocd-server' || true)
+          if [ -n "$hits" ]; then
+            echo "$hits"
+            echo "❌ Use 'service' or 'service.namespace' instead of a .svc.cluster.local FQDN."
+            exit 1
+          fi
+          echo "✅ No cluster.local FQDNs"
+
       - name: Create validation report
         if: always()
         run: |

--- a/infrastructure/base-configs/templates/pg-backup/cronjob.yaml
+++ b/infrastructure/base-configs/templates/pg-backup/cronjob.yaml
@@ -20,7 +20,7 @@ spec:
               command: ["/bin/sh", "/scripts/backup.sh"]
               env:
                 - name: PGHOST
-                  value: postgres-postgresql.databases.svc.cluster.local
+                  value: postgres-postgresql.databases
                 - name: PGPORT
                   value: "5432"
                 - name: PGUSER

--- a/infrastructure/configs/templates/argocd/notifications.yaml
+++ b/infrastructure/configs/templates/argocd/notifications.yaml
@@ -13,7 +13,7 @@ data:
     argocdUrl: https://argocd.{{ .Values.global.domains.internal }}
 
   service.webhook.ntfy: |
-    url: http://ntfy.operations.svc.cluster.local
+    url: http://ntfy.operations
     headers:
       - name: Authorization
         value: $ntfy-header

--- a/infrastructure/configs/templates/authentik/middleware-admin.yaml
+++ b/infrastructure/configs/templates/authentik/middleware-admin.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   forwardAuth:
-    address: http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/traefik?app=admin-auth
+    address: http://authentik-server.authentik/outpost.goauthentik.io/auth/traefik?app=admin-auth
     trustForwardHeader: true
     authResponseHeaders:
       - X-authentik-username

--- a/infrastructure/configs/templates/authentik/middleware.yaml
+++ b/infrastructure/configs/templates/authentik/middleware.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   forwardAuth:
-    address: http://authentik-server.authentik.svc.cluster.local/outpost.goauthentik.io/auth/traefik
+    address: http://authentik-server.authentik/outpost.goauthentik.io/auth/traefik
     trustForwardHeader: true
     authResponseHeaders:
       - X-authentik-username

--- a/infrastructure/controllers/authentik/values.yaml
+++ b/infrastructure/controllers/authentik/values.yaml
@@ -37,12 +37,12 @@ authentik:
     use_tls: true
     timeout: 10
   postgresql:
-    host: "postgres-postgresql.databases.svc.cluster.local"
+    host: "postgres-postgresql.databases"
     name: "authentik"
     user: "authentik"
     port: 5432
   redis:
-    host: "redis-master.databases.svc.cluster.local"
+    host: "redis-master.databases"
     port: 6379
   error_reporting:
     enabled: false

--- a/infrastructure/controllers/traefik/values.yaml
+++ b/infrastructure/controllers/traefik/values.yaml
@@ -123,7 +123,7 @@ tracing:
     enabled: true
     grpc:
       enabled: true
-      endpoint: "alloy.monitoring.svc.cluster.local:4317"
+      endpoint: "alloy.monitoring:4317"
       insecure: true
 
 # -----------------------------------------------------------------------------

--- a/infrastructure/system/falco/values.yaml
+++ b/infrastructure/system/falco/values.yaml
@@ -43,7 +43,7 @@ falcosidekick:
   config:
     # High-severity events -> existing Alertmanager -> alertmanager-ntfy -> ntfy
     alertmanager:
-      hostport: "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"
+      hostport: "http://kube-prometheus-stack-alertmanager.monitoring:9093"
       endpoint: "/api/v2/alerts"
       minimumpriority: "critical"
       extralabels: "source:falco"

--- a/services/home-automation/zigbee2mqtt/values.yaml
+++ b/services/home-automation/zigbee2mqtt/values.yaml
@@ -7,7 +7,7 @@ controllers:
           repository: ghcr.io/koenkk/zigbee2mqtt
           tag: 2.12.0@sha256:1debff565ab6841417bd9f7ce8ad44f8c5f25a8b02a24ce3fd79e4779a4763a5
         env:
-          ZIGBEE2MQTT_CONFIG_MQTT_SERVER: "mqtt://mosquitto.home-automation.svc.cluster.local:1883"
+          ZIGBEE2MQTT_CONFIG_MQTT_SERVER: "mqtt://mosquitto.home-automation:1883"
           ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"
           ZIGBEE2MQTT_CONFIG_FRONTEND_PORT: "8080"
           ZIGBEE2MQTT_CONFIG_SERIAL_PORT: "tcp://10.9.9.20:3333"

--- a/services/media/bazarr/manifests/bazarr-scripts.yaml
+++ b/services/media/bazarr/manifests/bazarr-scripts.yaml
@@ -27,11 +27,11 @@ data:
     import urllib.parse
     import urllib.request
 
-    JELLYFIN_URL = "http://jellyfin-main.media.svc.cluster.local:8096"
+    JELLYFIN_URL = "http://jellyfin-main.media:8096"
     JELLYFIN_TOKEN = os.environ.get("JELLYFIN_API_KEY", "")
     BAZARR_URL = "http://localhost:6767"
     BAZARR_APIKEY = os.environ.get("BAZARR_APIKEY", "")
-    LINGARR_URL = "http://lingarr.media.svc.cluster.local:8080"
+    LINGARR_URL = "http://lingarr.media:8080"
 
 
     def get_translate_targets():

--- a/services/media/cross-seed/manifests/cross-seed-scripts.yaml
+++ b/services/media/cross-seed/manifests/cross-seed-scripts.yaml
@@ -11,7 +11,7 @@ data:
     apk add --no-cache jq >/dev/null 2>&1
 
     echo "Fetching private torrent indexers from Prowlarr..."
-    PROWLARR_URL="http://prowlarr.media.svc.cluster.local:9696"
+    PROWLARR_URL="http://prowlarr.media:9696"
     INDEXERS=$(curl -sf "${PROWLARR_URL}/api/v1/indexer" \
       -H "X-Api-Key: ${PROWLARR_API_KEY}")
 
@@ -30,7 +30,7 @@ data:
     cat > /config/config.js << CONFIGJS
     export default {
       torrentClients: [
-        "qbittorrent:http://qbittorrent-main.media.svc.cluster.local:8080",
+        "qbittorrent:http://qbittorrent-main.media:8080",
       ],
       action: "inject",
       useClientTorrents: true,
@@ -50,13 +50,13 @@ data:
     ${TORZNAB}
       ],
       sonarr: [
-        "http://sonarr.media.svc.cluster.local:8989/?apikey=${SONARR_API_KEY}",
+        "http://sonarr.media:8989/?apikey=${SONARR_API_KEY}",
       ],
       radarr: [
-        "http://radarr.media.svc.cluster.local:7878/?apikey=${RADARR_API_KEY}",
+        "http://radarr.media:7878/?apikey=${RADARR_API_KEY}",
       ],
       lidarr: [
-        "http://lidarr.media.svc.cluster.local:8686/?apikey=${LIDARR_API_KEY}",
+        "http://lidarr.media:8686/?apikey=${LIDARR_API_KEY}",
       ],
       searchCadence: "1 day",
       rssCadence: "30 minutes",

--- a/services/media/dispatcharr/values.yaml
+++ b/services/media/dispatcharr/values.yaml
@@ -10,11 +10,11 @@ controllers:
         env:
           TZ: "Asia/Jerusalem"
           DISPATCHARR_ENV: "modular"
-          POSTGRES_HOST: "postgres-postgresql.databases.svc.cluster.local"
+          POSTGRES_HOST: "postgres-postgresql.databases"
           POSTGRES_PORT: "5432"
           POSTGRES_DB: "dispatcharr"
           POSTGRES_USER: "dispatch"
-          REDIS_HOST: "redis-master.databases.svc.cluster.local"
+          REDIS_HOST: "redis-master.databases"
           REDIS_PORT: "6379"
           REDIS_DB: "4"
         envFrom:
@@ -50,11 +50,11 @@ controllers:
           DISPATCHARR_ENV: "modular"
           DISPATCHARR_WEB_HOST: "dispatcharr"
           DISPATCHARR_PORT: "9191"
-          POSTGRES_HOST: "postgres-postgresql.databases.svc.cluster.local"
+          POSTGRES_HOST: "postgres-postgresql.databases"
           POSTGRES_PORT: "5432"
           POSTGRES_DB: "dispatcharr"
           POSTGRES_USER: "dispatch"
-          REDIS_HOST: "redis-master.databases.svc.cluster.local"
+          REDIS_HOST: "redis-master.databases"
           REDIS_PORT: "6379"
           REDIS_DB: "4"
         envFrom:

--- a/services/media/immich/values.yaml
+++ b/services/media/immich/values.yaml
@@ -11,7 +11,7 @@ controllers:
           DB_DATABASE_NAME: immich
           DB_USERNAME: immich
           DB_VECTOR_EXTENSION: "vectorchord"
-          REDIS_HOSTNAME: redis-master.databases.svc.cluster.local
+          REDIS_HOSTNAME: redis-master.databases
           REDIS_PORT: "6379"
           IMMICH_MACHINE_LEARNING_URL: "http://immich-machine-learning:3003"
         envFrom:

--- a/services/media/jellyfin/manifests/config.json
+++ b/services/media/jellyfin/manifests/config.json
@@ -1,6 +1,6 @@
 {
   "ldap": {
-    "server": "ak-outpost-ldap-outpost.authentik.svc.cluster.local",
+    "server": "ak-outpost-ldap-outpost.authentik",
     "port": 389,
     "bind_dn": "cn=ldapservice,ou=users,dc=ldap,dc=benplus,dc=app",
     "base_dn": "ou=users,dc=ldap,dc=benplus,dc=app",
@@ -8,7 +8,7 @@
     "group_base_dn": "ou=groups,dc=ldap,dc=benplus,dc=app"
   },
   "jellyfin": {
-    "url": "http://jellyfin-main.media.svc.cluster.local:8096"
+    "url": "http://jellyfin-main.media:8096"
   },
   "group_library_map": {
     "jellyfin-admins": ["*"],

--- a/services/media/lingarr/values.yaml
+++ b/services/media/lingarr/values.yaml
@@ -8,18 +8,18 @@ controllers:
         env:
           # Translation backend
           SERVICE_TYPE: "libretranslate"
-          LIBRE_TRANSLATE_URL: "http://libretranslate.media.svc.cluster.local:5000"
+          LIBRE_TRANSLATE_URL: "http://libretranslate.media:5000"
 
           # Database
           DB_CONNECTION: "postgres"
-          DB_HOST: "postgres-postgresql.databases.svc.cluster.local"
+          DB_HOST: "postgres-postgresql.databases"
           DB_PORT: "5432"
           DB_DATABASE: "lingarr"
           DB_USERNAME: "lingarr"
 
           # Sonarr / Radarr (EN instances only)
-          SONARR_URL: "http://sonarr.media.svc.cluster.local:8989"
-          RADARR_URL: "http://radarr.media.svc.cluster.local:7878"
+          SONARR_URL: "http://sonarr.media:8989"
+          RADARR_URL: "http://radarr.media:7878"
 
           # Languages
           SOURCE_LANGUAGES: '[{"name":"English","code":"en"}]'

--- a/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
+++ b/services/media/qbit-manage-ru/manifests/qbit-manage-ru-config.yaml
@@ -20,7 +20,7 @@ data:
       skip_cleanup: false
 
     qbt:
-      host: "http://qbittorrent-ru-main.media.svc.cluster.local:8080"
+      host: "http://qbittorrent-ru-main.media:8080"
 
     settings:
       force_auto_tmm: false

--- a/services/media/qbit-manage/manifests/qbit-manage-config.yaml
+++ b/services/media/qbit-manage/manifests/qbit-manage-config.yaml
@@ -20,7 +20,7 @@ data:
       skip_cleanup: false
 
     qbt:
-      host: "http://qbittorrent-main.media.svc.cluster.local:8080"
+      host: "http://qbittorrent-main.media:8080"
 
     settings:
       force_auto_tmm: false

--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -10,7 +10,7 @@ data:
 
     radarr:
       radarr_main:
-        base_url: http://radarr.media.svc.cluster.local:7878
+        base_url: http://radarr.media:7878
         api_key: !env_var RADARR_API_KEY
 
         delete_old_custom_formats: true
@@ -146,7 +146,7 @@ data:
                 score: 1000
 
       radarr_ru:
-        base_url: http://radarr-ru.media.svc.cluster.local:7878
+        base_url: http://radarr-ru.media:7878
         api_key: !env_var RADARR_RU_API_KEY
         delete_old_custom_formats: true
 
@@ -197,7 +197,7 @@ data:
 
     sonarr:
       sonarr_main:
-        base_url: http://sonarr.media.svc.cluster.local:8989
+        base_url: http://sonarr.media:8989
         api_key: !env_var SONARR_API_KEY
 
         delete_old_custom_formats: true
@@ -392,7 +392,7 @@ data:
               - name: Remux-1080p - Anime
 
       sonarr_ru:
-        base_url: http://sonarr-ru.media.svc.cluster.local:8989
+        base_url: http://sonarr-ru.media:8989
         api_key: !env_var SONARR_RU_API_KEY
         delete_old_custom_formats: true
 

--- a/services/media/unpackerr/values.yaml
+++ b/services/media/unpackerr/values.yaml
@@ -11,19 +11,19 @@ controllers:
           UN_WEBSERVER_METRICS: "true"
           UN_WEBSERVER_LISTEN_ADDR: "0.0.0.0:5656"
 
-          UN_RADARR_0_URL: "http://radarr.media.svc.cluster.local:7878"
+          UN_RADARR_0_URL: "http://radarr.media:7878"
           UN_RADARR_0_PATHS_0: "/data/torrents"
           UN_RADARR_0_PROTOCOLS: "torrent"
 
-          UN_RADARR_1_URL: "http://radarr-ru.media.svc.cluster.local:7878"
+          UN_RADARR_1_URL: "http://radarr-ru.media:7878"
           UN_RADARR_1_PATHS_0: "/data/torrents"
           UN_RADARR_1_PROTOCOLS: "torrent"
 
-          UN_SONARR_0_URL: "http://sonarr.media.svc.cluster.local:8989"
+          UN_SONARR_0_URL: "http://sonarr.media:8989"
           UN_SONARR_0_PATHS_0: "/data/torrents"
           UN_SONARR_0_PROTOCOLS: "torrent"
 
-          UN_SONARR_1_URL: "http://sonarr-ru.media.svc.cluster.local:8989"
+          UN_SONARR_1_URL: "http://sonarr-ru.media:8989"
           UN_SONARR_1_PATHS_0: "/data/torrents"
           UN_SONARR_1_PROTOCOLS: "torrent"
         envFrom:

--- a/services/operations/alertmanager-ntfy/manifests/configmap.yaml
+++ b/services/operations/alertmanager-ntfy/manifests/configmap.yaml
@@ -8,7 +8,7 @@ data:
     http:
       addr: :8000
     ntfy:
-      baseurl: http://ntfy.operations.svc.cluster.local
+      baseurl: http://ntfy.operations
       notification:
         topic: alerts
         priority: |

--- a/services/operations/alloy/values.yaml
+++ b/services/operations/alloy/values.yaml
@@ -170,7 +170,7 @@ alloy:
 
       loki.write "default" {
         endpoint {
-          url = "http://loki-gateway.monitoring.svc.cluster.local/loki/api/v1/push"
+          url = "http://loki-gateway.monitoring/loki/api/v1/push"
         }
       }
 
@@ -192,7 +192,7 @@ alloy:
 
       otelcol.exporter.otlp "tempo" {
         client {
-          endpoint = "tempo.monitoring.svc.cluster.local:4317"
+          endpoint = "tempo.monitoring:4317"
           tls {
             insecure = true
           }

--- a/services/operations/homepage-admin/manifests/templates/configmap.yaml
+++ b/services/operations/homepage-admin/manifests/templates/configmap.yaml
@@ -350,7 +350,7 @@ data:
             app: prometheus
             widget:
               type: prometheusmetric
-              url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              url: http://kube-prometheus-stack-prometheus.monitoring:9090
               refreshInterval: 30000
               metrics:
                 - label: Nodes Ready
@@ -371,7 +371,7 @@ data:
             app: prometheus
             widget:
               type: prometheusmetric
-              url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              url: http://kube-prometheus-stack-prometheus.monitoring:9090
               refreshInterval: 30000
               metrics:
                 - label: Failed Probes
@@ -407,7 +407,7 @@ data:
             app: prometheus
             widget:
               type: prometheusmetric
-              url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              url: http://kube-prometheus-stack-prometheus.monitoring:9090
               refreshInterval: 60000
               metrics:
                 - label: Active Bans
@@ -433,12 +433,12 @@ data:
             icon: jellyfin.png
             href: https://benplus.app
             description: Who is watching what
-            siteMonitor: http://jellyfin-main.media.svc.cluster.local:8096
+            siteMonitor: http://jellyfin-main.media:8096
             namespace: media
             app: jellyfin
             widget:
               type: jellyfin
-              url: http://jellyfin-main.media.svc.cluster.local:8096
+              url: http://jellyfin-main.media:8096
               key: {{ "{{" }}HOMEPAGE_VAR_JELLYFIN_KEY{{ "}}" }}
               enableBlocks: false
               enableNowPlaying: true
@@ -448,22 +448,22 @@ data:
             icon: qbittorrent.png
             href: https://qbittorrent.internal.starktastic.net
             description: Active transfers
-            siteMonitor: http://qbittorrent-main.media.svc.cluster.local:8080
+            siteMonitor: http://qbittorrent-main.media:8080
             namespace: media
             app: qbittorrent
             widget:
               type: qbittorrent
-              url: http://qbittorrent-main.media.svc.cluster.local:8080
+              url: http://qbittorrent-main.media:8080
         - Downloads RU:
             icon: qbittorrent.png
             href: https://qbittorrent-ru.internal.starktastic.net
             description: Active transfers — Russian trackers
-            siteMonitor: http://qbittorrent-ru-main.media.svc.cluster.local:8080
+            siteMonitor: http://qbittorrent-ru-main.media:8080
             namespace: media
             app: qbittorrent-ru
             widget:
               type: qbittorrent
-              url: http://qbittorrent-ru-main.media.svc.cluster.local:8080
+              url: http://qbittorrent-ru-main.media:8080
         - Deployments:
             icon: argo-cd.png
             href: https://argocd.internal.starktastic.net
@@ -473,7 +473,7 @@ data:
             app: argocd-server
             widget:
               type: prometheusmetric
-              url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              url: http://kube-prometheus-stack-prometheus.monitoring:9090
               refreshInterval: 30000
               metrics:
                 - label: Apps
@@ -488,12 +488,12 @@ data:
             icon: ntfy.png
             href: https://ntfy.starktastic.net
             description: Most recent notification
-            siteMonitor: http://ntfy.operations.svc.cluster.local:80
+            siteMonitor: http://ntfy.operations:80
             namespace: operations
             app: ntfy
             widget:
               type: ntfy
-              url: http://ntfy.operations.svc.cluster.local:80
+              url: http://ntfy.operations:80
               topic: alerts
               key: {{ "{{" }}HOMEPAGE_VAR_NTFY_TOKEN{{ "}}" }}
     - Coming Up:
@@ -530,12 +530,12 @@ data:
             icon: vikunja.png
             href: https://vikunja.starktastic.net
             description: Open tasks
-            siteMonitor: http://vikunja.operations.svc.cluster.local:3456
+            siteMonitor: http://vikunja.operations:3456
             namespace: operations
             app: vikunja
             widget:
               type: vikunja
-              url: http://vikunja.operations.svc.cluster.local:3456
+              url: http://vikunja.operations:3456
               key: {{ "{{" }}HOMEPAGE_VAR_VIKUNJA_KEY{{ "}}" }}
               enableTaskList: true
               version: 2
@@ -543,12 +543,12 @@ data:
             icon: mealie.png
             href: https://mealie.starktastic.net
             description: Recipe library
-            siteMonitor: http://mealie.operations.svc.cluster.local:9000
+            siteMonitor: http://mealie.operations:9000
             namespace: operations
             app: mealie
             widget:
               type: mealie
-              url: http://mealie.operations.svc.cluster.local:9000
+              url: http://mealie.operations:9000
               key: {{ "{{" }}HOMEPAGE_VAR_MEALIE_KEY{{ "}}" }}
               version: 2
     - Out There:
@@ -576,17 +576,17 @@ data:
             description: Movies, TV & anime
             namespace: media
             app: jellyfin
-            siteMonitor: http://jellyfin-main.media.svc.cluster.local:8096
+            siteMonitor: http://jellyfin-main.media:8096
         - Dispatcharr:
             icon: dispatcharr.png
             href: https://dispatcharr.internal.starktastic.net
             description: Live TV & IPTV proxy
-            siteMonitor: http://dispatcharr.media.svc.cluster.local:9191
+            siteMonitor: http://dispatcharr.media:9191
             namespace: media
             app: dispatcharr
             widget:
               type: dispatcharr
-              url: http://dispatcharr.media.svc.cluster.local:9191
+              url: http://dispatcharr.media:9191
               username: {{ "{{" }}HOMEPAGE_VAR_DISPATCHARR_USER{{ "}}" }}
               password: {{ "{{" }}HOMEPAGE_VAR_DISPATCHARR_PASS{{ "}}" }}
               enableActiveStreams: true
@@ -596,18 +596,18 @@ data:
             description: What is left to watch
             namespace: media
             app: cineplete
-            siteMonitor: http://cineplete.media.svc.cluster.local:8787
+            siteMonitor: http://cineplete.media:8787
     - Listen:
         - Navidrome:
             icon: navidrome.png
             href: https://music.benplus.app
             description: Music streaming
-            siteMonitor: http://navidrome.media.svc.cluster.local:4533
+            siteMonitor: http://navidrome.media:4533
             namespace: media
             app: navidrome
             widget:
               type: navidrome
-              url: http://navidrome.media.svc.cluster.local:4533
+              url: http://navidrome.media:4533
               user: {{ "{{" }}HOMEPAGE_VAR_NAVIDROME_USER{{ "}}" }}
               token: {{ "{{" }}HOMEPAGE_VAR_NAVIDROME_TOKEN{{ "}}" }}
               salt: {{ "{{" }}HOMEPAGE_VAR_NAVIDROME_SALT{{ "}}" }}
@@ -615,24 +615,24 @@ data:
             icon: audiobookshelf.png
             href: https://audiobooks.benplus.app
             description: Audiobooks & podcasts
-            siteMonitor: http://audiobookshelf.media.svc.cluster.local:80
+            siteMonitor: http://audiobookshelf.media:80
             namespace: media
             app: audiobookshelf
             widget:
               type: audiobookshelf
-              url: http://audiobookshelf.media.svc.cluster.local:80
+              url: http://audiobookshelf.media:80
               key: {{ "{{" }}HOMEPAGE_VAR_AUDIOBOOKSHELF_KEY{{ "}}" }}
     - Read:
         - Calibre-Web:
             icon: calibre-web.png
             href: https://books.benplus.app
             description: E-book library
-            siteMonitor: http://calibre-web.media.svc.cluster.local:8083/opds
+            siteMonitor: http://calibre-web.media:8083/opds
             namespace: media
             app: calibre-web
             widget:
               type: calibreweb
-              url: http://calibre-web.media.svc.cluster.local:8083
+              url: http://calibre-web.media:8083
               username: {{ "{{" }}HOMEPAGE_VAR_CALIBRE_USER{{ "}}" }}
               password: {{ "{{" }}HOMEPAGE_VAR_CALIBRE_PASS{{ "}}" }}
     - Look Back:
@@ -640,12 +640,12 @@ data:
             icon: immich.png
             href: https://photos.benplus.app
             description: Photos & videos
-            siteMonitor: http://immich-main.media.svc.cluster.local:2283
+            siteMonitor: http://immich-main.media:2283
             namespace: media
             app: immich
             widget:
               type: immich
-              url: http://immich-main.media.svc.cluster.local:2283
+              url: http://immich-main.media:2283
               key: {{ "{{" }}HOMEPAGE_VAR_IMMICH_KEY{{ "}}" }}
               version: 2
     - Ask For It:
@@ -653,23 +653,23 @@ data:
             icon: overseerr.png
             href: https://request.benplus.app
             description: Request movies & TV
-            siteMonitor: http://seerr.media.svc.cluster.local:5055
+            siteMonitor: http://seerr.media:5055
             namespace: media
             app: seerr
             widget:
               type: seerr
-              url: http://seerr.media.svc.cluster.local:5055
+              url: http://seerr.media:5055
               key: {{ "{{" }}HOMEPAGE_VAR_SEERR_KEY{{ "}}" }}
         - Seerr RU:
             icon: overseerr.png
             href: https://request-ru.benplus.app
             description: Requests — Russian trackers
-            siteMonitor: http://seerr-ru.media.svc.cluster.local:5055
+            siteMonitor: http://seerr-ru.media:5055
             namespace: media
             app: seerr-ru
             widget:
               type: seerr
-              url: http://seerr-ru.media.svc.cluster.local:5055
+              url: http://seerr-ru.media:5055
               key: {{ "{{" }}HOMEPAGE_VAR_SEERR_RU_KEY{{ "}}" }}
         - Shelfmark:
             icon: mdi-bookshelf
@@ -677,7 +677,7 @@ data:
             description: Request books
             namespace: media
             app: shelfmark
-            siteMonitor: http://shelfmark.media.svc.cluster.local:8084
+            siteMonitor: http://shelfmark.media:8084
     # ==================== MAKE ====================
     - Create:
         - Excalidash:
@@ -686,21 +686,21 @@ data:
             description: Whiteboard & diagrams
             namespace: operations
             app: excalidash
-            siteMonitor: http://excalidash.operations.svc.cluster.local:80
+            siteMonitor: http://excalidash.operations:80
         - ByteStash:
             icon: bytestash.png
             href: https://bytestash.internal.starktastic.net
             description: Code snippets
             namespace: operations
             app: bytestash
-            siteMonitor: http://bytestash.operations.svc.cluster.local:5000
+            siteMonitor: http://bytestash.operations:5000
         - MicroBin:
             icon: microbin.png
             href: https://microbin.starktastic.net
             description: Paste & share
             namespace: operations
             app: microbin
-            siteMonitor: http://microbin.operations.svc.cluster.local:8080
+            siteMonitor: http://microbin.operations:8080
     - Convert:
         - ConvertX:
             icon: convertx.png
@@ -708,28 +708,28 @@ data:
             description: File format converter
             namespace: operations
             app: convertx
-            siteMonitor: http://convertx.operations.svc.cluster.local:3000
+            siteMonitor: http://convertx.operations:3000
         - Stirling PDF:
             icon: stirling-pdf.png
             href: https://pdf.starktastic.net
             description: PDF toolbox
             namespace: operations
             app: stirling-pdf
-            siteMonitor: http://stirling-pdf.operations.svc.cluster.local:8080
+            siteMonitor: http://stirling-pdf.operations:8080
         - CyberChef:
             icon: cyberchef.png
             href: https://cyberchef.starktastic.net
             description: Encode, decode, analyse
             namespace: operations
             app: cyberchef
-            siteMonitor: http://cyberchef.operations.svc.cluster.local:8000
+            siteMonitor: http://cyberchef.operations:8000
         - MeTube:
             icon: metube.png
             href: https://metube.benplus.app
             description: Download video & audio
             namespace: media
             app: metube
-            siteMonitor: http://metube.media.svc.cluster.local:8081
+            siteMonitor: http://metube.media:8081
     - Find:
         - SearXNG:
             icon: searxng.png
@@ -737,28 +737,28 @@ data:
             description: Private metasearch
             namespace: operations
             app: searxng
-            siteMonitor: http://searxng.operations.svc.cluster.local:8080
+            siteMonitor: http://searxng.operations:8080
         - Karakeep:
             icon: karakeep.png
             href: https://karakeep.starktastic.net
             description: Bookmarks & read-later
-            siteMonitor: http://karakeep.operations.svc.cluster.local:3000
+            siteMonitor: http://karakeep.operations:3000
             namespace: operations
             app: karakeep
             widget:
               type: karakeep
-              url: http://karakeep.operations.svc.cluster.local:3000
+              url: http://karakeep.operations:3000
               key: {{ "{{" }}HOMEPAGE_VAR_KARAKEEP_KEY{{ "}}" }}
         - Changedetection:
             icon: changedetection.png
             href: https://changedetection.internal.starktastic.net
             description: Watch pages for changes
-            siteMonitor: http://changedetection.operations.svc.cluster.local:5000
+            siteMonitor: http://changedetection.operations:5000
             namespace: operations
             app: changedetection
             widget:
               type: changedetectionio
-              url: http://changedetection.operations.svc.cluster.local:5000
+              url: http://changedetection.operations:5000
               key: {{ "{{" }}HOMEPAGE_VAR_CHANGEDETECTION_KEY{{ "}}" }}
     - Organise:
         - Vikunja:
@@ -767,35 +767,35 @@ data:
             description: Tasks & projects
             namespace: operations
             app: vikunja
-            siteMonitor: http://vikunja.operations.svc.cluster.local:3456
+            siteMonitor: http://vikunja.operations:3456
         - Paperless-ngx:
             icon: paperless-ngx.png
             href: https://paperless.internal.starktastic.net
             description: Scanned documents
-            siteMonitor: http://paperless-ngx.operations.svc.cluster.local:8000
+            siteMonitor: http://paperless-ngx.operations:8000
             namespace: operations
             app: paperless-ngx
             widget:
               type: paperlessngx
-              url: http://paperless-ngx.operations.svc.cluster.local:8000
+              url: http://paperless-ngx.operations:8000
               key: {{ "{{" }}HOMEPAGE_VAR_PAPERLESS_KEY{{ "}}" }}
         - Filebrowser:
             icon: filebrowser.png
             href: https://files.internal.starktastic.net
             description: Web file manager
-            siteMonitor: http://filebrowser.operations.svc.cluster.local:80
+            siteMonitor: http://filebrowser.operations:80
             namespace: operations
             app: filebrowser
             widget:
               type: filebrowser
-              url: http://filebrowser.operations.svc.cluster.local:80
+              url: http://filebrowser.operations:80
         - Mealie:
             icon: mealie.png
             href: https://mealie.starktastic.net
             description: Recipes & shopping lists
             namespace: operations
             app: mealie
-            siteMonitor: http://mealie.operations.svc.cluster.local:9000
+            siteMonitor: http://mealie.operations:9000
     - Send:
         - PairDrop:
             icon: pairdrop.png
@@ -803,33 +803,33 @@ data:
             description: Device-to-device transfer
             namespace: operations
             app: pairdrop
-            siteMonitor: http://pairdrop.operations.svc.cluster.local:3000
+            siteMonitor: http://pairdrop.operations:3000
         - ntfy:
             icon: ntfy.png
             href: https://ntfy.starktastic.net
             description: Push notifications
             namespace: operations
             app: ntfy
-            siteMonitor: http://ntfy.operations.svc.cluster.local:80
+            siteMonitor: http://ntfy.operations:80
         - Listmonk:
             icon: listmonk.png
             href: https://listmonk.starktastic.net
             description: Newsletters & mailing lists
             namespace: operations
             app: listmonk
-            siteMonitor: http://listmonk.operations.svc.cluster.local:9000
+            siteMonitor: http://listmonk.operations:9000
     # ==================== RUN ====================
     - Acquire:
         - Radarr:
             icon: radarr.png
             href: https://radarr.internal.starktastic.net
             description: Movies
-            siteMonitor: http://radarr.media.svc.cluster.local:7878/ping
+            siteMonitor: http://radarr.media:7878/ping
             namespace: media
             app: radarr
             widget:
               type: radarr
-              url: http://radarr.media.svc.cluster.local:7878
+              url: http://radarr.media:7878
               key: {{ "{{" }}HOMEPAGE_VAR_RADARR_KEY{{ "}}" }}
               enableQueue: true
               highlight: &queue_depth
@@ -848,12 +848,12 @@ data:
             icon: radarr.png
             href: https://radarr-ru.internal.starktastic.net
             description: Movies — Russian trackers
-            siteMonitor: http://radarr-ru.media.svc.cluster.local:7878/ping
+            siteMonitor: http://radarr-ru.media:7878/ping
             namespace: media
             app: radarr-ru
             widget:
               type: radarr
-              url: http://radarr-ru.media.svc.cluster.local:7878
+              url: http://radarr-ru.media:7878
               key: {{ "{{" }}HOMEPAGE_VAR_RADARR_RU_KEY{{ "}}" }}
               enableQueue: true
               highlight: *queue_depth
@@ -861,12 +861,12 @@ data:
             icon: sonarr.png
             href: https://sonarr.internal.starktastic.net
             description: TV series
-            siteMonitor: http://sonarr.media.svc.cluster.local:8989/ping
+            siteMonitor: http://sonarr.media:8989/ping
             namespace: media
             app: sonarr
             widget:
               type: sonarr
-              url: http://sonarr.media.svc.cluster.local:8989
+              url: http://sonarr.media:8989
               key: {{ "{{" }}HOMEPAGE_VAR_SONARR_KEY{{ "}}" }}
               enableQueue: true
               highlight: *queue_depth
@@ -874,12 +874,12 @@ data:
             icon: sonarr.png
             href: https://sonarr-ru.internal.starktastic.net
             description: TV series — Russian trackers
-            siteMonitor: http://sonarr-ru.media.svc.cluster.local:8989/ping
+            siteMonitor: http://sonarr-ru.media:8989/ping
             namespace: media
             app: sonarr-ru
             widget:
               type: sonarr
-              url: http://sonarr-ru.media.svc.cluster.local:8989
+              url: http://sonarr-ru.media:8989
               key: {{ "{{" }}HOMEPAGE_VAR_SONARR_RU_KEY{{ "}}" }}
               enableQueue: true
               highlight: *queue_depth
@@ -887,40 +887,40 @@ data:
             icon: lidarr.png
             href: https://lidarr.internal.starktastic.net
             description: Music
-            siteMonitor: http://lidarr.media.svc.cluster.local:8686/ping
+            siteMonitor: http://lidarr.media:8686/ping
             namespace: media
             app: lidarr
             widget:
               type: lidarr
-              url: http://lidarr.media.svc.cluster.local:8686
+              url: http://lidarr.media:8686
               key: {{ "{{" }}HOMEPAGE_VAR_LIDARR_KEY{{ "}}" }}
         - Prowlarr:
             icon: prowlarr.png
             href: https://prowlarr.internal.starktastic.net
             description: Indexer manager
-            siteMonitor: http://prowlarr.media.svc.cluster.local:9696/ping
+            siteMonitor: http://prowlarr.media:9696/ping
             namespace: media
             app: prowlarr
             widget:
               type: prowlarr
-              url: http://prowlarr.media.svc.cluster.local:9696
+              url: http://prowlarr.media:9696
               key: {{ "{{" }}HOMEPAGE_VAR_PROWLARR_KEY{{ "}}" }}
         - Autobrr:
             icon: autobrr.png
             href: https://autobrr.internal.starktastic.net
             description: Release automation
-            siteMonitor: http://autobrr.media.svc.cluster.local:7474
+            siteMonitor: http://autobrr.media:7474
             namespace: media
             app: autobrr
             widget:
               type: autobrr
-              url: http://autobrr.media.svc.cluster.local:7474
+              url: http://autobrr.media:7474
               key: {{ "{{" }}HOMEPAGE_VAR_AUTOBRR_KEY{{ "}}" }}
         - Cleanuparr:
             icon: cleanuparr.png
             href: https://cleanuparr.internal.starktastic.net
             description: Stuck queue cleanup
-            siteMonitor: http://cleanuparr.media.svc.cluster.local:11011/health
+            siteMonitor: http://cleanuparr.media:11011/health
             namespace: media
             app: cleanuparr
         - qBittorrent:
@@ -929,25 +929,25 @@ data:
             description: Torrent client
             namespace: media
             app: qbittorrent
-            siteMonitor: http://qbittorrent-main.media.svc.cluster.local:8080
+            siteMonitor: http://qbittorrent-main.media:8080
         - qBittorrent RU:
             icon: qbittorrent.png
             href: https://qbittorrent-ru.internal.starktastic.net
             description: Torrent client — Russian trackers
             namespace: media
             app: qbittorrent-ru
-            siteMonitor: http://qbittorrent-ru-main.media.svc.cluster.local:8080
+            siteMonitor: http://qbittorrent-ru-main.media:8080
     - Refine:
         - Bazarr:
             icon: bazarr.png
             href: https://bazarr.internal.starktastic.net
             description: Subtitle fetching
-            siteMonitor: http://bazarr.media.svc.cluster.local:6767
+            siteMonitor: http://bazarr.media:6767
             namespace: media
             app: bazarr
             widget:
               type: bazarr
-              url: http://bazarr.media.svc.cluster.local:6767
+              url: http://bazarr.media:6767
               key: {{ "{{" }}HOMEPAGE_VAR_BAZARR_KEY{{ "}}" }}
         - Lingarr:
             icon: mdi-translate
@@ -955,18 +955,18 @@ data:
             description: Subtitle translation
             namespace: media
             app: lingarr
-            siteMonitor: http://lingarr.media.svc.cluster.local:8080
+            siteMonitor: http://lingarr.media:8080
     - Home:
         - Home Assistant:
             icon: home-assistant.png
             href: https://ha.internal.starktastic.net
             description: Smart home control
-            siteMonitor: http://home-assistant-main.home-automation.svc.cluster.local:8123
+            siteMonitor: http://home-assistant-main.home-automation:8123
             namespace: home-automation
             app: home-assistant
             widget:
               type: homeassistant
-              url: http://home-assistant-main.home-automation.svc.cluster.local:8123
+              url: http://home-assistant-main.home-automation:8123
               key: {{ "{{" }}HOMEPAGE_VAR_HASS_KEY{{ "}}" }}
         - Zigbee2MQTT:
             icon: zigbee2mqtt.png
@@ -974,19 +974,19 @@ data:
             description: Zigbee device bridge
             namespace: home-automation
             app: zigbee2mqtt
-            siteMonitor: http://zigbee2mqtt.home-automation.svc.cluster.local:8080
+            siteMonitor: http://zigbee2mqtt.home-automation:8080
     - Observe:
         - Grafana:
             icon: grafana.png
             href: https://grafana.internal.starktastic.net
             description: Dashboards & alerting
-            siteMonitor: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80/api/health
+            siteMonitor: http://kube-prometheus-stack-grafana.monitoring:80/api/health
             namespace: monitoring
             app: grafana
             widget:
               type: grafana
               alerts: alertmanager
-              url: http://kube-prometheus-stack-grafana.monitoring.svc.cluster.local:80
+              url: http://kube-prometheus-stack-grafana.monitoring:80
               username: {{ "{{" }}HOMEPAGE_VAR_GRAFANA_USER{{ "}}" }}
               password: {{ "{{" }}HOMEPAGE_VAR_GRAFANA_PASS{{ "}}" }}
               version: 2
@@ -994,23 +994,23 @@ data:
             icon: prometheus.png
             href: https://grafana.internal.starktastic.net/explore
             description: Metrics store
-            siteMonitor: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090/-/healthy
+            siteMonitor: http://kube-prometheus-stack-prometheus.monitoring:9090/-/healthy
             namespace: monitoring
             app: prometheus
             widget:
               type: prometheus
-              url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
+              url: http://kube-prometheus-stack-prometheus.monitoring:9090
     - Guard:
         - Authentik:
             icon: authentik.png
             href: https://auth.starktastic.net
             description: Identity provider & SSO
-            siteMonitor: http://authentik-server.authentik.svc.cluster.local:80
+            siteMonitor: http://authentik-server.authentik:80
             namespace: authentik
             app: authentik
             widget:
               type: authentik
-              url: http://authentik-server.authentik.svc.cluster.local:80
+              url: http://authentik-server.authentik:80
               key: {{ "{{" }}HOMEPAGE_VAR_AUTHENTIK_KEY{{ "}}" }}
               version: 2
         - Vaultwarden:
@@ -1019,14 +1019,14 @@ data:
             description: Password manager
             namespace: operations
             app: vaultwarden
-            siteMonitor: http://vaultwarden.operations.svc.cluster.local:8080
+            siteMonitor: http://vaultwarden.operations:8080
         - Falco:
             icon: mdi-shield-search
             href: https://falco.internal.starktastic.net
             description: Runtime threat detection
             namespace: falco
             app: falcosidekick
-            siteMonitor: http://falco-falcosidekick-ui.falco.svc.cluster.local:2802
+            siteMonitor: http://falco-falcosidekick-ui.falco:2802
     - Ship:
         - Argo CD:
             icon: argo-cd.png
@@ -1141,12 +1141,12 @@ data:
             icon: traefik.png
             href: https://traefik.internal.starktastic.net
             description: Ingress & reverse proxy
-            siteMonitor: http://traefik-api.traefik-system.svc.cluster.local:8080/ping
+            siteMonitor: http://traefik-api.traefik-system:8080/ping
             namespace: traefik-system
             app: traefik
             widget:
               type: traefik
-              url: http://traefik-api.traefik-system.svc.cluster.local:8080
+              url: http://traefik-api.traefik-system:8080
     - Store:
         - TrueNAS:
             icon: truenas.png
@@ -1165,7 +1165,7 @@ data:
             description: Database administration
             namespace: databases
             app: pgadmin4
-            siteMonitor: http://pgadmin-pgadmin4.databases.svc.cluster.local:80
+            siteMonitor: http://pgadmin-pgadmin4.databases:80
   bookmarks.yaml: |
     - Code:
         - apps:

--- a/services/operations/homepage/manifests/templates/configmap.yaml
+++ b/services/operations/homepage/manifests/templates/configmap.yaml
@@ -245,10 +245,10 @@ data:
             icon: jellyfin.png
             href: https://benplus.app
             description: Who is watching what
-            siteMonitor: http://jellyfin-main.media.svc.cluster.local:8096
+            siteMonitor: http://jellyfin-main.media:8096
             widget:
               type: jellyfin
-              url: http://jellyfin-main.media.svc.cluster.local:8096
+              url: http://jellyfin-main.media:8096
               key: {{ "{{" }}HOMEPAGE_VAR_JELLYFIN_KEY{{ "}}" }}
               enableBlocks: false
               enableNowPlaying: true
@@ -258,10 +258,10 @@ data:
             icon: navidrome.png
             href: https://music.benplus.app
             description: What is on the speakers
-            siteMonitor: http://navidrome.media.svc.cluster.local:4533
+            siteMonitor: http://navidrome.media:4533
             widget:
               type: navidrome
-              url: http://navidrome.media.svc.cluster.local:4533
+              url: http://navidrome.media:4533
               user: {{ "{{" }}HOMEPAGE_VAR_NAVIDROME_USER{{ "}}" }}
               token: {{ "{{" }}HOMEPAGE_VAR_NAVIDROME_TOKEN{{ "}}" }}
               salt: {{ "{{" }}HOMEPAGE_VAR_NAVIDROME_SALT{{ "}}" }}
@@ -276,21 +276,21 @@ data:
               firstDayInWeek: sunday
               integrations:
                 - type: ical
-                  url: http://sonarr.media.svc.cluster.local:8989/feed/v3/calendar/Sonarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_SONARR_KEY{{ "}}" }}
+                  url: http://sonarr.media:8989/feed/v3/calendar/Sonarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_SONARR_KEY{{ "}}" }}
                   name: TV
                   color: blue
                 - type: ical
-                  url: http://radarr.media.svc.cluster.local:7878/feed/v3/calendar/Radarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_RADARR_KEY{{ "}}" }}
+                  url: http://radarr.media:7878/feed/v3/calendar/Radarr.ics?apikey={{ "{{" }}HOMEPAGE_VAR_RADARR_KEY{{ "}}" }}
                   name: Movies
                   color: red
         - Tasks Due:
             icon: vikunja.png
             href: https://vikunja.starktastic.net
             description: Shared to-do lists
-            siteMonitor: http://vikunja.operations.svc.cluster.local:3456
+            siteMonitor: http://vikunja.operations:3456
             widget:
               type: vikunja
-              url: http://vikunja.operations.svc.cluster.local:3456
+              url: http://vikunja.operations:3456
               key: {{ "{{" }}HOMEPAGE_VAR_VIKUNJA_KEY{{ "}}" }}
               enableTaskList: true
               version: 2
@@ -300,27 +300,27 @@ data:
             icon: jellyfin.png
             href: https://benplus.app
             description: Movies, TV & anime
-            siteMonitor: http://jellyfin-main.media.svc.cluster.local:8096
+            siteMonitor: http://jellyfin-main.media:8096
     - Listen:
         - Navidrome:
             icon: navidrome.png
             href: https://music.benplus.app
             description: Music streaming
-            siteMonitor: http://navidrome.media.svc.cluster.local:4533
+            siteMonitor: http://navidrome.media:4533
         - Audiobookshelf:
             icon: audiobookshelf.png
             href: https://audiobooks.benplus.app
             description: Audiobooks & podcasts
-            siteMonitor: http://audiobookshelf.media.svc.cluster.local:80
+            siteMonitor: http://audiobookshelf.media:80
     - Read:
         - Calibre-Web:
             icon: calibre-web.png
             href: https://books.benplus.app
             description: E-book library
-            siteMonitor: http://calibre-web.media.svc.cluster.local:8083/opds
+            siteMonitor: http://calibre-web.media:8083/opds
             widget:
               type: calibreweb
-              url: http://calibre-web.media.svc.cluster.local:8083
+              url: http://calibre-web.media:8083
               username: {{ "{{" }}HOMEPAGE_VAR_CALIBRE_USER{{ "}}" }}
               password: {{ "{{" }}HOMEPAGE_VAR_CALIBRE_PASS{{ "}}" }}
     - Look Back:
@@ -328,10 +328,10 @@ data:
             icon: immich.png
             href: https://photos.benplus.app
             description: Photos & videos
-            siteMonitor: http://immich-main.media.svc.cluster.local:2283
+            siteMonitor: http://immich-main.media:2283
             widget:
               type: immich
-              url: http://immich-main.media.svc.cluster.local:2283
+              url: http://immich-main.media:2283
               key: {{ "{{" }}HOMEPAGE_VAR_IMMICH_KEY{{ "}}" }}
               version: 2
     - Ask For It:
@@ -339,100 +339,100 @@ data:
             icon: overseerr.png
             href: https://request.benplus.app
             description: Request movies & TV
-            siteMonitor: http://seerr.media.svc.cluster.local:5055
+            siteMonitor: http://seerr.media:5055
             widget:
               type: seerr
-              url: http://seerr.media.svc.cluster.local:5055
+              url: http://seerr.media:5055
               key: {{ "{{" }}HOMEPAGE_VAR_SEERR_KEY{{ "}}" }}
         - Seerr RU:
             icon: overseerr.png
             href: https://request-ru.benplus.app
             description: Request movies & TV (RU)
-            siteMonitor: http://seerr-ru.media.svc.cluster.local:5055
+            siteMonitor: http://seerr-ru.media:5055
             widget:
               type: seerr
-              url: http://seerr-ru.media.svc.cluster.local:5055
+              url: http://seerr-ru.media:5055
               key: {{ "{{" }}HOMEPAGE_VAR_SEERR_RU_KEY{{ "}}" }}
         - Shelfmark:
             icon: mdi-bookshelf
             href: https://request-books.benplus.app
             description: Request books
-            siteMonitor: http://shelfmark.media.svc.cluster.local:8084
+            siteMonitor: http://shelfmark.media:8084
     # ==================== MAKE ====================
     - Create:
         - Excalidash:
             icon: excalidraw.png
             href: https://excalidash.starktastic.net
             description: Whiteboard & diagrams
-            siteMonitor: http://excalidash.operations.svc.cluster.local:80
+            siteMonitor: http://excalidash.operations:80
         - MicroBin:
             icon: microbin.png
             href: https://microbin.starktastic.net
             description: Paste & share text
-            siteMonitor: http://microbin.operations.svc.cluster.local:8080
+            siteMonitor: http://microbin.operations:8080
     - Convert:
         - ConvertX:
             icon: convertx.png
             href: https://convertx.starktastic.net
             description: File format converter
-            siteMonitor: http://convertx.operations.svc.cluster.local:3000
+            siteMonitor: http://convertx.operations:3000
         - Stirling PDF:
             icon: stirling-pdf.png
             href: https://pdf.starktastic.net
             description: PDF toolbox
-            siteMonitor: http://stirling-pdf.operations.svc.cluster.local:8080
+            siteMonitor: http://stirling-pdf.operations:8080
         - MeTube:
             icon: metube.png
             href: https://metube.benplus.app
             description: Download video & audio
-            siteMonitor: http://metube.media.svc.cluster.local:8081
+            siteMonitor: http://metube.media:8081
         - CyberChef:
             icon: cyberchef.png
             href: https://cyberchef.starktastic.net
             description: Encode, decode, analyse
-            siteMonitor: http://cyberchef.operations.svc.cluster.local:8000
+            siteMonitor: http://cyberchef.operations:8000
     - Find:
         - SearXNG:
             icon: searxng.png
             href: https://search.starktastic.net
             description: Private metasearch
-            siteMonitor: http://searxng.operations.svc.cluster.local:8080
+            siteMonitor: http://searxng.operations:8080
         - Karakeep:
             icon: karakeep.png
             href: https://karakeep.starktastic.net
             description: Bookmarks & read-later
-            siteMonitor: http://karakeep.operations.svc.cluster.local:3000
+            siteMonitor: http://karakeep.operations:3000
             widget:
               type: karakeep
-              url: http://karakeep.operations.svc.cluster.local:3000
+              url: http://karakeep.operations:3000
               key: {{ "{{" }}HOMEPAGE_VAR_KARAKEEP_KEY{{ "}}" }}
     - Organise:
         - Vikunja:
             icon: vikunja.png
             href: https://vikunja.starktastic.net
             description: Tasks & projects
-            siteMonitor: http://vikunja.operations.svc.cluster.local:3456
+            siteMonitor: http://vikunja.operations:3456
         - Mealie:
             icon: mealie.png
             href: https://mealie.starktastic.net
             description: Recipes & shopping lists
-            siteMonitor: http://mealie.operations.svc.cluster.local:9000
+            siteMonitor: http://mealie.operations:9000
     - Send:
         - PairDrop:
             icon: pairdrop.png
             href: https://pairdrop.starktastic.net
             description: Device-to-device transfer
-            siteMonitor: http://pairdrop.operations.svc.cluster.local:3000
+            siteMonitor: http://pairdrop.operations:3000
         - ntfy:
             icon: ntfy.png
             href: https://ntfy.starktastic.net
             description: Push notifications
-            siteMonitor: http://ntfy.operations.svc.cluster.local:80
+            siteMonitor: http://ntfy.operations:80
         - Listmonk:
             icon: listmonk.png
             href: https://listmonk.starktastic.net
             description: Newsletters & mailing lists
-            siteMonitor: http://listmonk.operations.svc.cluster.local:9000
+            siteMonitor: http://listmonk.operations:9000
   bookmarks.yaml: |
     - Links:
         - My Account:

--- a/services/operations/kube-prometheus-stack/values.yaml
+++ b/services/operations/kube-prometheus-stack/values.yaml
@@ -88,7 +88,7 @@ alertmanager:
         webhook_configs:
           # Routes through alertmanager-ntfy adapter for formatted notifications
           # with proper titles, descriptions, priority, and tags
-          - url: "http://alertmanager-ntfy.monitoring.svc.cluster.local:8000/hook"
+          - url: "http://alertmanager-ntfy.monitoring:8000/hook"
             send_resolved: true
     inhibit_rules:
       - source_matchers:
@@ -147,14 +147,14 @@ grafana:
       type: loki
       uid: loki
       access: proxy
-      url: http://loki-gateway.monitoring.svc.cluster.local
+      url: http://loki-gateway.monitoring
       jsonData:
         maxLines: 250
     - name: Tempo
       type: tempo
       uid: tempo
       access: proxy
-      url: http://tempo.monitoring.svc.cluster.local:3200
+      url: http://tempo.monitoring:3200
       jsonData:
         tracesToLogsV2:
           datasourceUid: loki

--- a/services/operations/listmonk/manifests/sync-cronjob.yaml
+++ b/services/operations/listmonk/manifests/sync-cronjob.yaml
@@ -23,8 +23,8 @@ spec:
                 - |
                   set -e
 
-                  AUTHENTIK_URL="http://authentik-server.authentik.svc.cluster.local"
-                  LISTMONK_URL="http://listmonk.operations.svc.cluster.local:9000"
+                  AUTHENTIK_URL="http://authentik-server.authentik"
+                  LISTMONK_URL="http://listmonk.operations:9000"
                   LIST_ID=3
                   EXCLUDE_EMAILS="root@example.com,benfaingold@gmail.com"
 

--- a/services/operations/paperless-ngx/values.yaml
+++ b/services/operations/paperless-ngx/values.yaml
@@ -10,7 +10,7 @@ controllers:
             memory: 640Mi
         env:
           # Database
-          PAPERLESS_DBHOST: "postgres-postgresql.databases.svc.cluster.local"
+          PAPERLESS_DBHOST: "postgres-postgresql.databases"
           PAPERLESS_DBPORT: "5432"
           PAPERLESS_DBNAME: "paperless"
           PAPERLESS_DBUSER: "paperless"

--- a/services/operations/prometheus-blackbox-exporter/manifests/probe-external.yaml
+++ b/services/operations/prometheus-blackbox-exporter/manifests/probe-external.yaml
@@ -10,7 +10,7 @@ spec:
   interval: 60s
   module: icmp
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:
@@ -31,7 +31,7 @@ spec:
   interval: 60s
   module: dns_cloudflare
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:
@@ -52,7 +52,7 @@ spec:
   interval: 60s
   module: http_2xx
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:
@@ -73,12 +73,12 @@ spec:
   interval: 60s
   module: tcp_connect
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:
       static:
-        - alertmanager-ntfy.monitoring.svc.cluster.local:8000
+        - alertmanager-ntfy.monitoring:8000
       labels:
         service: alertmanager-ntfy
         tier: alert-pipeline
@@ -94,7 +94,7 @@ spec:
   interval: 60s
   module: http_auth
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:
@@ -115,7 +115,7 @@ spec:
   interval: 60s
   module: http_auth
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:

--- a/services/operations/tempo/values.yaml
+++ b/services/operations/tempo/values.yaml
@@ -7,7 +7,7 @@ tempo:
   reportingEnabled: false
   metricsGenerator:
     enabled: true
-    remoteWriteUrl: "http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090/api/v1/write"
+    remoteWriteUrl: "http://kube-prometheus-stack-prometheus.monitoring:9090/api/v1/write"
   retention: 72h
   receivers:
     otlp:

--- a/services/operations/vikunja/values.yaml
+++ b/services/operations/vikunja/values.yaml
@@ -11,7 +11,7 @@ controllers:
           VIKUNJA_SERVICE_ENABLEREGISTRATION: "false"
           # Database (shared PostgreSQL)
           VIKUNJA_DATABASE_TYPE: "postgres"
-          VIKUNJA_DATABASE_HOST: "postgres-postgresql.databases.svc.cluster.local"
+          VIKUNJA_DATABASE_HOST: "postgres-postgresql.databases"
           VIKUNJA_DATABASE_DATABASE: "vikunja"
           VIKUNJA_DATABASE_USER: "vikunja"
           VIKUNJA_DATABASE_SSLMODE: "disable"

--- a/templates/ingress-chart/templates/probe.yaml
+++ b/templates/ingress-chart/templates/probe.yaml
@@ -12,7 +12,7 @@ spec:
   interval: 60s
   module: {{ $module }}
   prober:
-    url: prometheus-blackbox-exporter.monitoring.svc.cluster.local:9115
+    url: prometheus-blackbox-exporter.monitoring:9115
     scheme: http
   targets:
     staticConfig:


### PR DESCRIPTION
## Problem

Pods run with `options ndots:5`. A name like `postgres-postgresql.databases.svc.cluster.local` has **4 dots — one short of the threshold**, so the resolver tries the entire search list *before* trying the name as written:

| # | Query actually sent | Result |
|---|---|---|
| 1 | `…svc.cluster.local.databases.svc.cluster.local` | NXDOMAIN (cached by CoreDNS) |
| 2 | `…svc.cluster.local.svc.cluster.local` | NXDOMAIN (cached) |
| 3 | `…svc.cluster.local.cluster.local` | NXDOMAIN (cached) |
| 4 | `…svc.cluster.local.mgmt.arpa` | **leaves the cluster → AdGuard** |
| 5 | `postgres-postgresql.databases.svc.cluster.local` | NOERROR ✅ |

Step 4 is the node's inherited search domain. dnsmasq answers `local=/mgmt.arpa/` with an **SOA-less NXDOMAIN**, which per RFC 2308 cannot be negatively cached — so CoreDNS re-forwards it on *every single lookup*, forever.

Measured live on the cluster: **1,044 forwarded NXDOMAIN/min (~1.5M/day)**, of which 58% came from one reference — `libretranslate.media.svc.cluster.local` in `lingarr/values.yaml`.

## Evidence

Control experiment using a service nothing else queries, counted on the AdGuard side by exact query name (10 lookups per arm):

| Written in config | Hits search entry | **Queries reaching AdGuard** |
|---|---|---|
| `audiobookshelf` | #1 | **0** |
| `audiobookshelf.media` | #2 | **0** |
| `audiobookshelf.media.svc.cluster.local` | #5 | **30** |
| `audiobookshelf.media.svc.cluster.local.` | absolute | **0** |

`service.namespace` was also verified **cross-namespace** (pod in `databases` → service in `media`): **zero leaks**. So the short form is safe regardless of which namespace the caller lives in — it hits `svc.cluster.local` on attempt #2.

## Change

Mechanical: strip `.svc.cluster.local`, leaving `service.namespace`. No namespace analysis required, since the form works identically same-ns and cross-ns.

- **178 occurrences rewritten across 29 files** (diff is exactly 178 insertions / 178 deletions — pure 1:1 substitution)
- **3 deliberately kept** because they are TLS endpoints where a certificate SAN could depend on the FQDN:
  - `crowdsecLapiHost` (`crowdsecLapiScheme: https`; there is a documented plan to enable cert verification)
  - `siteMonitor: https://argocd-server.argocd.svc.cluster.local:443` ×2

## Verification

- ✅ **All 59 distinct resulting names resolve in-cluster** (checked live via `getent` from a running pod, 0 failures)
- ✅ `yamllint` with the repo's own config — passes
- ✅ `kubeconform` on changed manifests — 13 resources, 0 invalid
- ✅ `helm template` renders for `homepage`, `homepage-admin`, `ingress-chart`
- ✅ `jellyfin/manifests/config.json` still parses as JSON
- ℹ️ `infrastructure/configs` does not render standalone — confirmed **pre-existing on `main`** via a throwaway worktree (Argo supplies `global.domains`)

## Regression guard

One `git grep` step added to `validate-and-diff.yml`. Tested both directions: passes on this tree, fails when an FQDN is reintroduced. Without it, this silently accumulates again — that is how it reached 181 occurrences.

## Blast radius

All 77 Argo CD Applications have `syncPolicy.automated.enabled: false`, so **merging changes Git only — nothing deploys until you sync**. When you do sync, apps whose env vars / ConfigMaps changed will roll their pods. Expected and safe: every target name is already proven resolvable.

## Relationship to ansible#223

This addresses the same noise at its actual source. The kubelet `--resolv-conf` change in [ansible#223](https://github.com/Starktastic-Homelab/ansible/pull/223) removes `mgmt.arpa` from pod search paths entirely, which would be a belt-and-braces safety net for any FQDN that slips past the guard — but with this PR merged it is no longer the primary fix. Reasonable to close it.


## ⚠️ Reading the Argo CD diff preview

The preview compares this branch against the **live cluster**, so it also surfaces pre-existing drift that has nothing to do with this PR. Verified examples:

| App in preview | Caused by this PR? |
|---|---|
| `sealed-secrets (+1\|-1)` | ❌ **0 files** from this commit — pre-existing drift |
| `qbittorrent (+1\|-1)` | ❌ **0 files** from this commit — pre-existing drift |
| `kube-prometheus-stack (+171\|-171)` | ⚠️ only **3 lines** are mine; the other ~168 are a chart-version drift (`88.5.0` live vs `88.3.0` in Git) |
| `alertmanager-ntfy (+11\|-11)` | ✅ mine, but it is **one** substitution inside a folded YAML scalar that re-wraps across 11 lines |

Since every Application has automated sync disabled, this drift has been accumulating independently. Worth a separate look — it is not introduced here.
