### PR TITLE
fix(storage): pin storageClassName on Helm-rendered PVCs too

### DIFF
--- a/bootstrap/appsets/cluster-apps.yaml
+++ b/bootstrap/appsets/cluster-apps.yaml
@@ -100,14 +100,6 @@ spec:
           kind: Secret
           jsonPointers:
             - /data
-        - group: ""
-          kind: PersistentVolumeClaim
-          jsonPointers:
-            # PVC spec is immutable post-bind. We dropped the explicit
-            # `storageClassName: nfs-pv` from values now that nfs-pv is the
-            # sole cluster default, but bound PVCs still report it on the
-            # live side, which Argo would otherwise flag as drift forever.
-            - /spec/storageClassName
         - group: apps
           kind: Deployment
           jqPathExpressions:

--- a/bootstrap/appsets/config-apps.yaml
+++ b/bootstrap/appsets/config-apps.yaml
@@ -76,11 +76,3 @@ spec:
             duration: 15s
             factor: 2
             maxDuration: 5m
-      ignoreDifferences:
-        - group: ""
-          kind: PersistentVolumeClaim
-          jsonPointers:
-            # See cluster-apps.yaml for the rationale (PVC spec.storageClassName
-            # is immutable post-bind, but dropped from desired manifests now
-            # that nfs-pv is the sole cluster default).
-            - /spec/storageClassName

--- a/docs/adr/0009-explicit-storageclass-over-default.md
+++ b/docs/adr/0009-explicit-storageclass-over-default.md
@@ -6,61 +6,113 @@
 ## Context
 
 k3s ships a packaged `local-storage` AddOn that declares the `local-path` StorageClass with
-`storageclass.kubernetes.io/is-default-class: "true"`. We want `nfs-pv` (RWX, NFS-backed,
-survives node loss) to be the class our workloads land on.
+`storageclass.kubernetes.io/is-default-class: "true"`. We want `nfs-pv` (RWX, NFS-backed, survives node loss) to be the
+class our workloads land on.
 
-To get there we used to ship `infrastructure/system/nfs-provisioner/manifests/local-path-default-off.yaml`,
-which re-declared `local-path` with the annotation flipped to `"false"`. Its comment claimed this
-gave us "exactly one default class".
+To get there we used to ship `infrastructure/system/nfs-provisioner/manifests/local-path-default-off.yaml`, which
+re-declared `local-path` with the annotation flipped to `"false"`. Its comment claimed this gave us "exactly one default
+class".
 
-It never did. k3s re-writes its packaged manifests to disk and re-applies them **on every k3s
-start**, so the annotation flipped back on every restart — and k3s restarts often here (29 times
-in the 14 days before this ADR). The observable result was:
+It never did. k3s re-writes its packaged manifests to disk and re-applies them **on every k3s start**, so the annotation
+flipped back on every restart — and k3s restarts often here (29 times in the 14 days before this ADR). The observable
+result was:
 
-- Two StorageClasses marked default simultaneously (`local-path` *and* `nfs-pv`).
-- The `nfs-provisioner` Argo Application permanently `OutOfSync` on `StorageClass/local-path`,
-  which masked any *real* drift in that Application.
-- Workload storage silently depending on the DefaultStorageClass admission plugin's
-  multiple-default tiebreak: newest `creationTimestamp` wins. `nfs-pv` only won because it was
-  created 100 seconds after `local-path` on 2026-08-12.
+- Two StorageClasses marked default simultaneously (`local-path` _and_ `nfs-pv`).
+- The `nfs-provisioner` Argo Application permanently `OutOfSync` on `StorageClass/local-path`, which masked any _real_
+  drift in that Application.
+- Workload storage silently depending on the DefaultStorageClass admission plugin's multiple-default tiebreak: newest
+  `creationTimestamp` wins. `nfs-pv` only won because it was created 100 seconds after `local-path` on 2026-08-12.
 
 ## Decision
 
 Stop fighting k3s over the default-class annotation.
 
 1. Delete `local-path-default-off.yaml`. Let k3s own `local-path` entirely.
-2. Set `storageClassName: nfs-pv` explicitly on the 21 PVCs that previously rode the default.
-3. Keep `nfs-pv`'s own `defaultClass: true` (in `values.yaml`) as a safety net for anything new
-   that forgets — but nothing in the repo depends on it any more.
+2. Set `storageClassName: nfs-pv` explicitly on every PVC that previously rode the default — raw manifests _and_
+   Helm-rendered ones (see the 2026-08-23 update below).
+3. Keep `nfs-pv`'s own `defaultClass: true` (in `values.yaml`) as a safety net for anything new that forgets — but
+   nothing in the repo depends on it any more.
 
 ## Rationale
 
-The deleted file could not work by construction: any Argo-managed declaration of that annotation
-loses to k3s's AddOn controller on the next restart. Enabling `selfHeal` on the Application would
-only have shortened the window, not closed it, and would have contradicted the repo-wide choice to
-keep Argo auto-sync off.
+The deleted file could not work by construction: any Argo-managed declaration of that annotation loses to k3s's AddOn
+controller on the next restart. Enabling `selfHeal` on the Application would only have shortened the window, not closed
+it, and would have contradicted the repo-wide choice to keep Argo auto-sync off.
 
-Making the 21 PVCs explicit was verified to be a **no-op against the live cluster**: the
-DefaultStorageClass admission plugin had already mutated each of those PVCs to
-`storageClassName: nfs-pv` at creation time, so Git now simply states what the cluster already
-holds. (`spec.storageClassName` is immutable post-bind, so this was the only safe direction.)
+Making the 21 PVCs explicit was verified to be a **no-op against the live cluster**: the DefaultStorageClass admission
+plugin had already mutated each of those PVCs to `storageClassName: nfs-pv` at creation time, so Git now simply states
+what the cluster already holds. (`spec.storageClassName` is immutable post-bind, so this was the only safe direction.)
 
 Alternatives considered and rejected:
 
-- **`--disable local-storage`** — would remove the SC entirely and give us a single default.
-  Rejected: `media/jellyfin-cache` is a 50Gi RWO transcode cache that genuinely wants node-local
-  disk, and disabling the AddOn deletes the SC its PVC binds through.
-- **A `.skip` file for `local-storage.yaml`** — stops k3s managing the AddOn, so an Argo-owned SC
-  would stick. Rejected: we would inherit the whole local-path-provisioner Deployment, RBAC and
-  image version, on every server node, for one annotation.
-- **Leaving the default ambiguous** (delete the file and nothing else) — works today, but a future
-  k3s upgrade that recreates the `local-path` SC would make it the newest default and silently
-  send new PVCs to node-local disk.
+- **`--disable local-storage`** — would remove the SC entirely and give us a single default. Rejected:
+  `media/jellyfin-cache` is a 50Gi RWO transcode cache that genuinely wants node-local disk, and disabling the AddOn
+  deletes the SC its PVC binds through.
+- **A `.skip` file for `local-storage.yaml`** — stops k3s managing the AddOn, so an Argo-owned SC would stick. Rejected:
+  we would inherit the whole local-path-provisioner Deployment, RBAC and image version, on every server node, for one
+  annotation.
+- **Leaving the default ambiguous** (delete the file and nothing else) — works today, but a future k3s upgrade that
+  recreates the `local-path` SC would make it the newest default and silently send new PVCs to node-local disk.
 
 ## Consequences
 
 - `nfs-provisioner` can reach `Synced` and stay there, so drift in it is meaningful again.
 - Storage choice is self-documenting at each PVC instead of resolved implicitly at admission time.
 - Two classes remain annotated as default, but nothing in the repo relies on which one wins.
-- **New PVCs must set `storageClassName` explicitly.** Omitting it is no longer a supported
-  pattern here, even though it would still happen to work.
+- **New PVCs must set `storageClassName` explicitly.** Omitting it is no longer a supported pattern here, even though it
+  would still happen to work.
+
+## Update (2026-08-23): the tiebreak flipped, and the first pass was incomplete
+
+The last rejected alternative above guessed that "a future k3s upgrade that recreates the `local-path` SC would make it
+the newest default". That was too optimistic — it takes no upgrade. k3s re-applies the AddOn on **every start**, so
+`local-path` is recreated with a fresh `creationTimestamp` each time. Measured immediately after the next k3s restart:
+
+```
+local-path   2026-08-23T00:44:12Z   is-default=true    # minutes old
+nfs-pv       2026-08-12T20:59:52Z   is-default=true    # 10 days old
+```
+
+`local-path` is therefore **permanently** the newest default and permanently wins the tiebreak. Confirmed with a
+server-side dry-run (persists nothing):
+
+```
+$ kubectl create --dry-run=server -f - <<< '<PVC with no storageClassName>'
+ponytail-tiebreak-probe -> storageClass=local-path
+```
+
+The first pass only pinned PVCs declared as **raw manifests**. Every Helm-rendered PVC was still riding the default.
+`global.storageClass` in `templates/globals.yaml` does not help: `app-template` ignores it (verified by rendering the
+chart with and without it). Rendering all `app-template` services showed **24 of 24 PVCs with no `storageClassName` at
+all**, plus three unpinned volume claims in `kube-prometheus-stack`.
+
+Had any of those PVCs been recreated, a volume declaring `ReadWriteMany` would have been satisfied by node-local RWO
+`local-path`, and its data would have disappeared on the next reschedule — silently, because both ApplicationSets
+carried an `ignoreDifferences` entry hiding `/spec/storageClassName`.
+
+So, additionally:
+
+4. Pin `storageClass: nfs-pv` in `templates/common.yaml`, which is applied as `commonValues` to every service and so
+   covers the shared `config` volume in one place.
+5. Pin the five service-local volumes that are not named `config`, and the three `kube-prometheus-stack` claims
+   (grafana, prometheus, alertmanager).
+6. Drop the `/spec/storageClassName` `ignoreDifferences` from both ApplicationSets. It was added on the premise that the
+   field had been "dropped from desired manifests now that nfs-pv is the sole cluster default" — both halves of which
+   are now false. With every PVC pinned, Git and the cluster agree, so the field can be diffed honestly again.
+
+Verified the same way as the first pass: rendering every `app-template` service goes from 24 `<UNSET>` to 24 `nfs-pv`,
+and all 24 match the live cluster exactly — a provable no-op that only closes the future-recreation hole.
+
+### Note on the immutable StatefulSets
+
+`prometheus` and `alertmanager` store through `volumeClaimTemplates`, which are immutable. Setting `storageClassName` on
+a live StatefulSet is a 422 `Invalid` update, which prometheus-operator handles by **deleting and recreating the
+StatefulSet** (`ForceUpdateStatefulSet` in `pkg/k8s/statefulset.go`, `DeletePropagationForeground`).
+
+This is safe _here_, and was checked before making the change: both StatefulSets have
+`persistentVolumeClaimRetentionPolicy: {whenDeleted: Retain, whenScaled: Retain}` and their PVCs carry **no
+`ownerReferences`**, so the volumes survive and are re-adopted by name. The cost is a pod restart on the next sync.
+
+The same is _not_ true of `loki`, whose STS is `whenDeleted: Delete` and whose PVC **is** owner-referenced — deleting
+that StatefulSet would delete its volume. Loki and tempo were already pinned, so no change was needed there; the check
+is recorded here because the next person to touch a `volumeClaimTemplate` needs to run it first.

--- a/services/media/cineplete/values.yaml
+++ b/services/media/cineplete/values.yaml
@@ -33,6 +33,7 @@ persistence:
   data:
     enabled: true
     type: persistentVolumeClaim
+    storageClass: nfs-pv
     size: 1Gi
     accessMode: ReadWriteMany
     globalMounts:

--- a/services/media/libretranslate/values.yaml
+++ b/services/media/libretranslate/values.yaml
@@ -43,6 +43,7 @@ persistence:
     enabled: false
   libretranslate-models:
     type: persistentVolumeClaim
+    storageClass: nfs-pv
     size: 2Gi
     accessMode: ReadWriteMany
     globalMounts:

--- a/services/media/lingarr/values.yaml
+++ b/services/media/lingarr/values.yaml
@@ -59,6 +59,7 @@ persistence:
     enabled: false
   lingarr-config:
     type: persistentVolumeClaim
+    storageClass: nfs-pv
     size: 1Gi
     accessMode: ReadWriteMany
     globalMounts:

--- a/services/operations/kube-prometheus-stack/values.yaml
+++ b/services/operations/kube-prometheus-stack/values.yaml
@@ -35,6 +35,13 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
+          # Must stay explicit: k3s's local-path StorageClass is recreated as
+          # a default on every restart, so it always wins the newest-wins
+          # tiebreak. Changing this on a live STS is an immutable-field update;
+          # prometheus-operator handles it by deleting and recreating the STS
+          # (ForceUpdateStatefulSet). PVCs survive - they have no ownerRefs and
+          # persistentVolumeClaimRetentionPolicy is Retain - but pods restart.
+          storageClassName: nfs-pv
           accessModes: ["ReadWriteMany"]
           resources:
             requests:
@@ -49,6 +56,9 @@ alertmanager:
     storage:
       volumeClaimTemplate:
         spec:
+          # See the prometheus storageSpec comment above: same immutable-STS
+          # caveat, same Retain retention policy, same ownerRef-free PVC.
+          storageClassName: nfs-pv
           accessModes: ["ReadWriteMany"]
           resources:
             requests:
@@ -140,6 +150,7 @@ grafana:
       capture: true
   persistence:
     enabled: true
+    storageClassName: nfs-pv
     accessModes: ["ReadWriteMany"]
     size: 2Gi
   additionalDataSources:

--- a/services/operations/ntfy/values.yaml
+++ b/services/operations/ntfy/values.yaml
@@ -36,6 +36,7 @@ persistence:
 
   cache:
     enabled: true
+    storageClass: nfs-pv
     accessMode: ReadWriteMany
     size: 5Gi
     globalMounts:

--- a/services/operations/searxng/values.yaml
+++ b/services/operations/searxng/values.yaml
@@ -47,6 +47,7 @@ persistence:
   cache:
     enabled: true
     type: persistentVolumeClaim
+    storageClass: nfs-pv
     size: 256Mi
     accessMode: ReadWriteMany
     globalMounts:

--- a/templates/common.yaml
+++ b/templates/common.yaml
@@ -32,6 +32,11 @@ persistence:
   config:
     enabled: true
     type: persistentVolumeClaim
+    # Must stay explicit. k3s recreates its local-path StorageClass (also
+    # annotated default) on every restart, so it is always the newest default
+    # and always wins the DefaultStorageClass newest-wins tiebreak. Omitting
+    # this silently puts an RWX volume on node-local RWO storage.
+    storageClass: nfs-pv
     size: 1Gi
     accessMode: ReadWriteMany
     globalMounts:


### PR DESCRIPTION
Follow-up to #1084. That PR pinned `storageClassName` on raw PVC manifests; every **Helm-rendered** PVC was missed and is still riding the cluster default.

## The default flipped

k3s re-applies its `local-storage` AddOn on **every start**, so `local-path` is recreated with a fresh `creationTimestamp`:

```
local-path   2026-08-23T00:44:12Z   is-default=true   # minutes old
nfs-pv       2026-08-12T20:59:52Z   is-default=true   # 10 days old
```

It is therefore *permanently* the newest default and permanently wins the `DefaultStorageClass` newest-wins tiebreak. Confirmed with a server-side dry-run (persists nothing):

```
ponytail-tiebreak-probe -> storageClass=local-path
```

ADR 0009 predicted this would need "a future k3s upgrade". It needs no upgrade — just a restart.

## Blast radius

Rendering every `app-template` service against the real values chain (`globals → common → extras → service`) gave **24 of 24 PVCs with no `storageClassName` at all**, plus three unpinned claims in `kube-prometheus-stack`. `global.storageClass` in `globals.yaml` does not cover them — `app-template` ignores it (verified by rendering with and without).

A recreated PVC declaring `ReadWriteMany` would have been satisfied by node-local RWO `local-path` and lost its data on the next reschedule — **silently**, because both ApplicationSets carried an `ignoreDifferences` entry hiding `/spec/storageClassName`.

## Changes

| | |
|---|---|
| `templates/common.yaml` | `storageClass: nfs-pv` — one line, covers the shared `config` volume for every service |
| 5 service values | the volumes not named `config` (cineplete, libretranslate, lingarr, ntfy `cache`, searxng `cache`) |
| `kube-prometheus-stack` | grafana `persistence`, prometheus `storageSpec`, alertmanager `storage` |
| both ApplicationSets | dropped the `/spec/storageClassName` `ignoreDifferences` |
| ADR 0009 | recorded the flip, the gap, and the STS check |

The `ignoreDifferences` comment asserted the field had been *"dropped from desired manifests now that nfs-pv is the sole cluster default"* — both halves are now false. With every PVC pinned, Git and the cluster agree, so the field can be diffed honestly.

## Verification

Rendered every `app-template` service on `main`, then on this branch, and compared both to the live cluster:

```
BASELINE (main):     24 <UNSET>
WITH CHANGE:         24 nfs-pv
mismatches vs live:  0
```

`kube-prometheus-stack` renders `storageClassName: nfs-pv` on all three claims. Prettier clean.

## ⚠️ One thing to know before syncing

`prometheus` and `alertmanager` store through `volumeClaimTemplates`, which are **immutable**. Setting `storageClassName` on a live StatefulSet is a 422 `Invalid` update, which prometheus-operator handles by **deleting and recreating the StatefulSet** ([`ForceUpdateStatefulSet`](https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/k8s/statefulset.go), `DeletePropagationForeground`).

I checked this is safe here before making the change — both StatefulSets have:

```
persistentVolumeClaimRetentionPolicy = {whenDeleted: Retain, whenScaled: Retain}
PVC ownerReferences                  = 0
```

so the volumes survive and are re-adopted by name. **Cost is a prometheus/alertmanager pod restart on sync.** Auto-sync is off cluster-wide, so this happens only when you choose.

For contrast, `loki` is `whenDeleted: Delete` with an owner-referenced PVC — deleting *that* STS would delete its volume. Loki and tempo were already pinned, so nothing changes for them; the check is written into the ADR for whoever touches a `volumeClaimTemplate` next.

## Not changed

`RespectIgnoreDifferences=true` is now a no-op in `config-apps.yaml` (its only `ignoreDifferences` entry was the PVC one). Left alone as pre-existing and harmless — say the word if you'd rather it go.
