### PR TITLE
fix(storage): pin storageClass for crowdsec and pgadmin PVCs

### DIFF
--- a/docs/adr/0009-explicit-storageclass-over-default.md
+++ b/docs/adr/0009-explicit-storageclass-over-default.md
@@ -116,3 +116,34 @@ This is safe _here_, and was checked before making the change: both StatefulSets
 The same is _not_ true of `loki`, whose STS is `whenDeleted: Delete` and whose PVC **is** owner-referenced — deleting
 that StatefulSet would delete its volume. Loki and tempo were already pinned, so no change was needed there; the check
 is recorded here because the next person to touch a `volumeClaimTemplate` needs to run it first.
+
+## Update (2026-08-24): the second pass was incomplete too — `commonValues` does not reach `infrastructure/**`
+
+The pass above pinned every service by adding `storageClass: nfs-pv` to `templates/common.yaml`. That file reaches an
+app only if the ApplicationSet generator passes it as `commonValues`, and in `bootstrap/appsets/cluster-apps.yaml` only
+the `services/**` generator does — `infrastructure/**` is generated with `commonValues: ""`.
+
+So `crowdsec` and `pgadmin` kept rendering `storageClassName: null` against live PVCs bound to `nfs-pv`. With the
+`ignoreDifferences` entry now gone, Argo tried to null an immutable field and the API server refused:
+
+```text
+PersistentVolumeClaim "crowdsec-db-pvc" is invalid: spec: Forbidden:
+spec is immutable after creation except resources.requests and
+volumeAttributesClassName for bound claims
+```
+
+A bound PVC's spec is immutable, so this never converges — it just retries. crowdsec reached retry #7 and pgadmin #10
+before it was noticed. Fixed by pinning in each app's own `values.yaml`.
+
+**The generalisable part:** `templates/common.yaml` is a `services/**` mechanism, not a repo-wide one. Anything under
+`infrastructure/**` must set storage explicitly in its own values file, using **that chart's** key — they are not
+interchangeable, and none of these three are:
+
+| Chart                  | Key                                           |
+| ---------------------- | --------------------------------------------- |
+| `app-template` (5.1.0) | `persistence.<name>.storageClass`             |
+| `pgadmin4` (1.66.0)    | `persistentVolume.storageClass`               |
+| `crowdsec` (0.24.0)    | `lapi.persistentVolume.data.storageClassName` |
+
+`app-template` additionally **ignores** `global.storageClass`, so there is no repo-wide shortcut available even for the
+services. Read the key out of `helm show values` rather than assuming it.

--- a/infrastructure/controllers/databases/pgadmin/values.yaml
+++ b/infrastructure/controllers/databases/pgadmin/values.yaml
@@ -18,6 +18,10 @@ envVarsExtra:
 persistentVolume:
   enabled: true
   size: 1Gi
+  # Must stay explicit. infrastructure/** apps get commonValues: "" from the
+  # appset, so templates/common.yaml never reaches them and this has to be
+  # pinned per chart. See docs/adr/0009-explicit-storageclass-over-default.md.
+  storageClass: nfs-pv
 serverDefinitions:
   enabled: true
   resourceType: ConfigMap

--- a/infrastructure/system/crowdsec/values.yaml
+++ b/infrastructure/system/crowdsec/values.yaml
@@ -57,6 +57,10 @@ lapi:
       accessModes:
         - ReadWriteMany
       size: 1Gi
+      # Must stay explicit. infrastructure/** apps get commonValues: "" from the
+      # appset, so templates/common.yaml never reaches them and this has to be
+      # pinned per chart. See docs/adr/0009-explicit-storageclass-over-default.md.
+      storageClassName: nfs-pv
     config:
       # Disabled with TLS: the chart's persistent config startup command (cp -nR)
       # copies default local_api_credentials.yaml with login/password into the PVC,


### PR DESCRIPTION
## Problem

`crowdsec` and `pgadmin` have been stuck `OutOfSync` / operation phase `Running`, retrying forever (crowdsec on retry #7, pgadmin on #10):

```text
PersistentVolumeClaim "crowdsec-db-pvc" is invalid: spec: Forbidden:
spec is immutable after creation except resources.requests and
volumeAttributesClassName for bound claims

- "StorageClassName": "nfs-pv",   <- live
+ "StorageClassName": null,       <- desired (git)
```

A bound PVC's spec is immutable except `resources.requests` and `volumeAttributesClassName`. Argo tries to null the field, the API server refuses, and the operation retries — it can never converge on its own.

## Root cause

#1086 removed the `/spec/storageClassName` `ignoreDifferences` from both ApplicationSets, and pinned every chart that renders a PVC. But the services were pinned centrally, via `templates/common.yaml`.

That file only reaches an app if the generator passes it as `commonValues`, and in `bootstrap/appsets/cluster-apps.yaml` only the `services/**` generator does. `infrastructure/**` is generated with `commonValues: ""`.

`crowdsec` and `pgadmin` are the only two `infrastructure/**` apps with a chart-rendered PVC, so they were the entire blast radius — every other Application is `Synced`.

## Fix

Pin the value in each chart's own `values.yaml`, using the key that chart actually reads. These are **not** interchangeable, and were taken from `helm show values` rather than assumed:

| App     | Chart              | Key                                           |
| ------- | ------------------ | --------------------------------------------- |
| pgadmin | `pgadmin4` 1.66.0  | `persistentVolume.storageClass`               |
| crowdsec| `crowdsec` 0.24.0  | `lapi.persistentVolume.data.storageClassName` |

## Verification

Rendered both charts with `templates/globals.yaml` layered exactly as the appset does.

Before — reproduces the reported `null`:

```text
pgadmin-pgadmin4   <no storageClassName>
crowdsec-db-pvc    <no storageClassName>
```

After:

```text
pgadmin-pgadmin4   storageClassName: "nfs-pv"   accessModes: [ReadWriteOnce]
crowdsec-db-pvc    storageClassName: "nfs-pv"   accessModes: [ReadWriteMany]
```

Against live:

```text
crowdsec    crowdsec-db-pvc    nfs-pv   Bound   ReadWriteMany
databases   pgadmin-pgadmin4   nfs-pv   Bound   ReadWriteOnce
```

Rendered output matches live on both `storageClassName` and `accessModes`, so the diff resolves rather than being retried. No PVC is recreated and no data moves.

## Also

ADR 0009 gets a third update recording the generalisable part: `templates/common.yaml` is a `services/**` mechanism, not a repo-wide one, and `app-template` ignores `global.storageClass` so there is no repo-wide shortcut at all.

## After merge

Both apps need a sync to pick this up (auto-sync is off cluster-wide). The stuck operations will keep retrying until then — happy to terminate and re-sync them on your say-so.
