### PR TITLE
fix(argocd): surface sync drift and stop RollingSync disabling it on configs

### DIFF
--- a/bootstrap/appsets/config-apps.yaml
+++ b/bootstrap/appsets/config-apps.yaml
@@ -18,31 +18,20 @@ spec:
         elements:
           - name: base-configs
             path: infrastructure/base-configs
-            deployPhase: foundation
           - name: infra-configs
             path: infrastructure/configs
-            deployPhase: services
-  strategy:
-    type: RollingSync
-    rollingSync:
-      steps:
-        - matchExpressions:
-            - key: deploy-phase
-              operator: In
-              values:
-                - foundation
-        - matchExpressions:
-            - key: deploy-phase
-              operator: In
-              values:
-                - services
+  # No strategy: RollingSync would force autosync off on both Applications (see
+  # the ArgoCDAppOutOfSync alert), and it bought no ordering here. base-configs is
+  # storage PVs/PVCs plus backup CronJobs, infra-configs is IngressRoutes,
+  # Middlewares and Certificates -- neither depends on the other. Ordering against
+  # the CRD providers in cluster-apps was never provided anyway, since RollingSync
+  # only sequences within a single ApplicationSet; spec.template's retry (30
+  # attempts, backing off to 5m) is what actually covers that race.
   template:
     metadata:
       name: "{{.name}}"
       namespace: argocd
       finalizers: ["resources-finalizer.argocd.argoproj.io"]
-      labels:
-        deploy-phase: "{{.deployPhase}}"
       annotations:
         notifications.argoproj.io/subscribe.on-sync-failed.ntfy: ""
         notifications.argoproj.io/subscribe.on-health-degraded.ntfy: ""

--- a/services/operations/kube-prometheus-stack/manifests/custom-rules.yaml
+++ b/services/operations/kube-prometheus-stack/manifests/custom-rules.yaml
@@ -50,3 +50,22 @@ spec:
           annotations:
             summary: "Alertmanager target down"
             description: "An Alertmanager scrape target ({{ $labels.job }}) has been down for 5 minutes."
+    # Both appsets use strategy.type RollingSync, which force-disables autosync on
+    # every Application it generates and only re-queues one when its target revision
+    # or generated spec changes. Cluster drift is neither, so a drifted app sits
+    # OutOfSync indefinitely with nothing to heal it -- and because it never attempts
+    # a sync, on-sync-failed never fires and nothing notifies. This is the only thing
+    # that catches that class of rot. `for` outlasts the OutOfSync window of a normal
+    # rollout, so ordinary deploys stay quiet.
+    - name: argocd
+      rules:
+        - alert: ArgoCDAppOutOfSync
+          expr: argocd_app_info{sync_status="OutOfSync"} == 1
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "ArgoCD application out of sync ({{ $labels.name }})"
+            description:
+              "Application {{ $labels.name }} has been OutOfSync for over an hour. Autosync is disabled by RollingSync,
+              so this will not heal on its own -- sync it manually or land a commit that changes it."


### PR DESCRIPTION
Follow-up to the `infra-configs` investigation in Starktastic-Homelab/ansible#228. That PR fixes the specific ConfigMap; this one fixes the two reasons nobody noticed for however long it was broken.

## Gap 1 — RollingSync makes `selfHeal: true` dead config

`applicationset/progressivesync/progressive_sync.go` only ever queues an app for sync here:

```go
if revisionsChanged || specChanged {
    newAppStatus.Status = argov1alpha1.ProgressiveSyncWaiting
```

`revisionsChanged` = a new git commit. `specChanged` = the generated **Application spec** differs from live. **Cluster drift is neither**, so a drifted app stays `Healthy` in the appset status indefinitely and is never re-queued. The [docs](https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/applicationset/Progressive-Syncs.md) line *"RollingSync will capture external changes outside the ApplicationSet resource"* refers to edits to the Application resource, not resource drift.

Live confirmation straight from ArgoCD's own metrics — `argocd_app_info` carries an `autosync_enabled` label:

```
argocd_app_info{name="infra-configs", autosync_enabled="false", health_status="Healthy", sync_status="OutOfSync"} 1
```

All 76 appset-generated apps report `autosync_enabled="false"`. The only app that doesn't is `cluster-bootstrap`, which Ansible creates directly — and it's the only one the application controller logs auto-sync decisions for.

## Gap 2 — drift is completely silent

Both appsets subscribe only:

```
notifications.argoproj.io/subscribe.on-sync-failed.ntfy
notifications.argoproj.io/subscribe.on-health-degraded.ntfy
```

An app that is `OutOfSync` **and `Healthy`** never *attempts* a sync, so nothing fails and nothing degrades. It matches no trigger. That's the exact state `infra-configs` was in.

## Changes

**1. `ArgoCDAppOutOfSync` alert** added to the existing `homelab-custom-alerts` PrometheusRule.

Chose Prometheus over an ArgoCD notification trigger deliberately: `for: 1h` outlasts the OutOfSync window of a normal rollout, and ArgoCD triggers have no duration concept — `when: app.status.sync.status == 'OutOfSync'` would fire on every commit in the gap before the sync lands. The alertmanager `route` already has a catch-all `receiver: "ntfy"`, so this needs no routing change, no new template, no new file.

**2. Dropped `strategy` from `config-apps`.**

It bought no ordering. `base-configs` is storage PVs/PVCs plus backup CronJobs; `infra-configs` is IngressRoutes, Middlewares and Certificates — neither depends on the other. Ordering against the CRD providers in `cluster-apps` was never provided anyway, since RollingSync only sequences *within* a single ApplicationSet; the template's `retry` (30 attempts, backing off to 5m) is what actually covers that race. Removing it restores real self-heal on the two apps most likely to be contended by the Ansible-side helm release.

Also dropped the now-dead `deployPhase` generator keys and the `deploy-phase` label that referenced them — required, since `goTemplateOptions: ["missingkey=error"]`.

**`cluster-apps` keeps RollingSync.** `crds → foundation → controllers → services` across 74 apps is load-bearing on a cold rebuild; the alert is the safety net there instead.

## Verification

- `kubeconform -strict` with the CRDs-catalog schema location (same as CI): `1 resource found - Valid: 1, Invalid: 0`.
- `prettier --check` on the rules file: `All matched files use Prettier code style!`
- Alert expression run against live Prometheus — `status: success`, returning exactly one series: `infra-configs`. So it's valid PromQL and it fires on the real case today.

## Expected after merge

`infra-configs` and `base-configs` regain `automated.enabled: true`, so `infra-configs` self-heals the notifications ConfigMap without the manual sync that Starktastic-Homelab/ansible#228 currently calls for. Merging this one **first** makes that PR's manual step unnecessary.