### PR TITLE
fix(reloader): reload every workload on config change

### DIFF
--- a/bootstrap/appsets/cluster-apps.yaml
+++ b/bootstrap/appsets/cluster-apps.yaml
@@ -107,8 +107,17 @@ spec:
             - '.spec.template.metadata.annotations["checksum/lapi-configmap"]'
             # Stakater Reloader stamps this on restart; without ignoring it,
             # selfHeal strips it and Reloader re-adds it, forever.
-            # Only Deployments opt in today — add StatefulSet/DaemonSet blocks
-            # if a workload of those kinds ever gets reloader.stakater.com/auto.
+            - '.spec.template.metadata.annotations["reloader.stakater.com/last-reloaded-from"]'
+        # Reloader runs with autoReloadAll, so it stamps StatefulSets and
+        # DaemonSets too — Traefik is a DaemonSet, and the monitoring and
+        # logging charts generate both kinds.
+        - group: apps
+          kind: StatefulSet
+          jqPathExpressions:
+            - '.spec.template.metadata.annotations["reloader.stakater.com/last-reloaded-from"]'
+        - group: apps
+          kind: DaemonSet
+          jqPathExpressions:
             - '.spec.template.metadata.annotations["reloader.stakater.com/last-reloaded-from"]'
   templatePatch: |
     {{- $repo := "https://github.com/Starktastic-Homelab/apps.git" }}

--- a/infrastructure/system/reloader/values.yaml
+++ b/infrastructure/system/reloader/values.yaml
@@ -5,8 +5,20 @@ reloader:
   # fight Reloader over every restart.
   reloadStrategy: annotations
 
-  # Opt-in only: workloads must carry reloader.stakater.com/auto: "true".
-  autoReloadAll: false
+  # Reload every workload that mounts a changed ConfigMap or Secret. Opt a
+  # workload out with reloader.stakater.com/auto: "false".
+  #
+  # This was opt-in until a widget deleted from the homepage ConfigMap kept
+  # running: the config is mounted with subPath, which Kubernetes never
+  # updates in a live pod, and homepage carried no annotation. 27 workloads
+  # mount config that way and only 2 had opted in, so the same trap was set
+  # 25 more times.
+  autoReloadAll: true
+
+  # monitoring is excluded because Prometheus and Alertmanager already
+  # hot-reload through their config-reloader sidecars — a pod restart there
+  # is redundant and costs a WAL replay.
+  ignoreNamespaces: "monitoring"
 
   # ServiceMonitor is deprecated upstream in favour of PodMonitor.
   podMonitor:

--- a/services/operations/filebrowser/values.yaml
+++ b/services/operations/filebrowser/values.yaml
@@ -1,7 +1,5 @@
 controllers:
   main:
-    annotations:
-      reloader.stakater.com/auto: "true"
     containers:
       main:
         image:

--- a/services/operations/homepage-admin/values.yaml
+++ b/services/operations/homepage-admin/values.yaml
@@ -1,7 +1,5 @@
 controllers:
   main:
-    annotations:
-      reloader.stakater.com/auto: "true"
     serviceAccount:
       name: homepage-admin
     containers:

--- a/services/operations/homepage-admin/values.yaml
+++ b/services/operations/homepage-admin/values.yaml
@@ -1,5 +1,7 @@
 controllers:
   main:
+    annotations:
+      reloader.stakater.com/auto: "true"
     serviceAccount:
       name: homepage-admin
     containers:

--- a/services/operations/ntfy/values.yaml
+++ b/services/operations/ntfy/values.yaml
@@ -1,7 +1,5 @@
 controllers:
   main:
-    annotations:
-      reloader.stakater.com/auto: "true"
     containers:
       main:
         image:


### PR DESCRIPTION
Fixes the `API Error: Failed to authenticate with Filebrowser` left over after #1092, then fixes the reason it was possible.

### Cause

Both homepage dashboards mount config with `subPath`:

```yaml
globalMounts:
  - path: /app/config/services.yaml
    subPath: services.yaml
```

Kubernetes does not propagate ConfigMap updates into `subPath` mounts — the file in a running pod is frozen at creation. #1092 removed the Filebrowser widget, Argo updated the ConfigMap, and the pod kept serving the old `services.yaml`, so the widget went on calling `/api/login`, which Quantum does not implement. Waiting would never have fixed it; only a pod restart would.

### Why this is broader than homepage

Reloader has been opt-in since #1047 (`autoReloadAll: false`). **27 workloads mount a ConfigMap or Secret and exactly 2 had opted in** — `ntfy` and `filebrowser`. Homepage was simply the one that broke visibly. Annotating apps one bug at a time sets the same trap 25 more times, so this flips the default instead.

### Changes

| File | Change |
|------|--------|
| `infrastructure/system/reloader/values.yaml` | `autoReloadAll: true`, `ignoreNamespaces: monitoring` |
| `bootstrap/appsets/cluster-apps.yaml` | `ignoreDifferences` blocks for `StatefulSet` and `DaemonSet` |
| `ntfy`, `filebrowser`, `homepage-admin` values | drop the now-redundant annotations |

Opt a workload out with `reloader.stakater.com/auto: "false"`.

### The StatefulSet/DaemonSet blocks are load-bearing

`cluster-apps.yaml` only ignored Reloader's `last-reloaded-from` annotation on `kind: Deployment`, with a comment saying to add StatefulSet/DaemonSet blocks if a workload of those kinds was ever annotated. `autoReloadAll` annotates all of them at once — Traefik is a DaemonSet, and the monitoring and logging charts generate both kinds. Without these blocks those apps stamp an annotation Argo does not ignore and sit permanently OutOfSync.

### Why monitoring is excluded

Prometheus and Alertmanager already hot-reload through their config-reloader sidecars. A Reloader restart there is redundant and costs a WAL replay.

Traefik and Authentik stay in scope deliberately: both restart only when a mounted secret is deliberately rotated, and both need the restart to pick it up. Traefik is a DaemonSet, so it rolls per-node rather than dropping ingress wholesale.

### Verification

Rendered flags:

```
--namespaces-to-ignore=monitoring
--reload-strategy=annotations
--auto-reload-all=true
```

`ignoreDifferences` after the change:

```
Secret           -> 1 expr
apps Deployment  -> 3 expr
apps StatefulSet -> 1 expr
apps DaemonSet   -> 1 expr
```

Checked for non-deterministic rendered config that would restart pods on every sync — no `randAlphaNum`, `uuidv4`, `genCA` or `now` anywhere in the repo, so there is none.

`yamllint` clean, homepage coverage `OK: 48 hosts, both dashboards consistent`, no `reloader.stakater.com/auto` annotations left outside the reloader chart itself.

### After merging

**A sync alone will not fix the stale widget.** This PR leaves `homepage-admin`'s Deployment byte-identical to main (the branch adds the annotation, then removes it again once `autoReloadAll` makes it redundant), so there is nothing for Argo to roll. Reloader only acts on a *future* ConfigMap change, and the change that removed the widget already happened in #1092.

So restart `homepage-admin` once by hand — Argo's Restart action on the Deployment, or `kubectl rollout restart`. That clears the stale `services.yaml`. Every config change after this reloads on its own, which is the whole point.

The rest of the change is inert until something actually changes: the flags take effect on the next Reloader sync, and no workload restarts merely because `autoReloadAll` flipped.

