### PR TITLE
fix(media): set a reachable upgrade cutoff for the Sonarr anime profile

### DIFF
--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -251,7 +251,15 @@ data:
             upgrade:
               allowed: true
               until_quality: Bluray-1080p
-              until_score: 10000
+              # The TRaSH default of 10000 is unreachable for this profile, so
+              # every file stayed cutoff-unmet forever and Sonarr re-hunted the
+              # whole anime library on every RSS/search pass. The best release
+              # actually obtainable here is Anime BD Tier 01 + Anime Dual Audio
+              # + FLAC + Season Pack = 3652 (measured across the library; the
+              # next tier down, Tier 03, scores 3450). 3600 sits just under
+              # that ceiling, so a Tier 01 grab satisfies the cutoff and the
+              # search stops, while Tier 03 files still upgrade toward it.
+              until_score: 3600
             qualities:
               - name: Bluray-1080p
                 qualities:


### PR DESCRIPTION
## Problem

The `Remux-1080p - Anime` profile used the TRaSH default `until_score: 10000`. That score is **unreachable**:

| Profile | Files | Median | p95 | Max observed | Cutoff | Files reaching cutoff |
|---|---|---|---|---|---|---|
| Remux-1080p - Anime | 243 | 3450 | 3450 | **3652** | 10000 | **0** |

Because the cutoff was never met, Sonarr treated every anime episode as permanently upgradable and re-hunted the profile on every RSS/search pass. Library-wide, 3345 of 4086 episode files (82%) were cutoff-unmet.

With `minUpgradeFormatScore = 1`, Sonarr grabbed anything worth a single point. History showed the same episode grabbed repeatedly as marginally better releases appeared:

```
President Curtis S01E05:  EDITH (0) -> NORViNE (1825) -> FLUX (3525)
Lanterns S01E02:          ETHEL (0) -> CAKES (1500)  -> FLUX (6375)
```

Grabs that finished after another release had already upgraded the file then failed to import as *"Not a Custom Format upgrade for existing episode file(s)"* — the queue clog that Cleanuparr (#1051) currently sweeps every 5 minutes. This addresses the cause rather than the symptom.

## Why 3600

Measured composition of the anime score tiers:

| Score | Files | Custom formats |
|---|---|---|
| 3225 | 60 | Anime Dual Audio, FLAC, Remux Tier 01, Season Pack |
| 3450 | 131 | Anime BD **Tier 03**, Anime Dual Audio, FLAC, Season Pack |
| 3652 | 12 | Anime BD **Tier 01**, Anime Dual Audio, FLAC, Season Pack, x265, 10bit, v2 |

3652 is a genuinely top-tier release, not noise. 3600 sits just under it, so a Tier 01 grab satisfies the cutoff and the search **terminates**, while Tier 03 files still upgrade toward Tier 01. Hunting becomes productive and finite instead of guaranteed-futile.

## Scope

Only the anime profile changes. `WEB-2160p` keeps `until_score: 10000` — its ceiling (9010 observed, 0 of 3828 files reaching 10000) is also unreachable, but whether to keep chasing quality there is a deliberate preference rather than a clear defect, so it is left alone.

## Verification

- [x] `pre-commit run --files services/media/recyclarr/manifests/recyclarr-config.yaml` — prettier + yamllint pass
- [x] Embedded `recyclarr.yml` still parses; anime `until_score` = 3600, WEB-2160p unchanged at 10000
- [x] Other four `until_score: 10000` occurrences (radarr_main, radarr_ru, sonarr_main WEB-2160p, sonarr_ru) untouched

Recyclarr runs `@daily`, so Sonarr's `cutoffFormatScore` updates on the next sync.