### PR TITLE
Revert "fix(media): set a reachable upgrade cutoff for the Sonarr anime profile"

### DIFF
--- a/services/media/recyclarr/manifests/recyclarr-config.yaml
+++ b/services/media/recyclarr/manifests/recyclarr-config.yaml
@@ -251,15 +251,7 @@ data:
             upgrade:
               allowed: true
               until_quality: Bluray-1080p
-              # The TRaSH default of 10000 is unreachable for this profile, so
-              # every file stayed cutoff-unmet forever and Sonarr re-hunted the
-              # whole anime library on every RSS/search pass. The best release
-              # actually obtainable here is Anime BD Tier 01 + Anime Dual Audio
-              # + FLAC + Season Pack = 3652 (measured across the library; the
-              # next tier down, Tier 03, scores 3450). 3600 sits just under
-              # that ceiling, so a Tier 01 grab satisfies the cutoff and the
-              # search stops, while Tier 03 files still upgrade toward it.
-              until_score: 3600
+              until_score: 10000
             qualities:
               - name: Bluray-1080p
                 qualities:


### PR DESCRIPTION
Reverts #1095, which was merged on an incorrect diagnosis.

## Why

#1095 claimed that the unreachable `until_score: 10000` left the anime library permanently cutoff-unmet, causing Sonarr to re-hunt it and produce the failed-import queue clog. Measuring the **complete** cutoff-unmet list after merging disproved that:

| Profile | Files | Cutoff-unmet | `until_quality` |
|---|---|---|---|
| WEB-2160p | 3843 | **3328** | Bluray-2160p Remux |
| Remux-1080p - Anime | 243 | **17** | Bluray-1080p |

The anime profile was never the problem. Its 17 unmet files are exactly its 9 `WEBDL-1080p` + 8 `WEBDL-2160p` files — qualities outside the profile. Its 214 `Bluray-1080p Remux` files scored 3225–3450 against a cutoff of 10000 and were still reported as cutoff **met**.

**Sonarr's Cutoff Unmet list is driven by the quality cutoff (`until_quality`), not by `cutoffFormatScore`.** An unreachable `until_score` does not make files cutoff-unmet.

Confirmed empirically: after #1095 applied `cutoffFormatScore=3600` and recyclarr synced it, the library-wide unmet total stayed at **3345, unchanged** — the change had no practical effect.

The original error came from sampling only the first 2000 of 3345 unmet records sorted by air date descending; anime series skew older and were under-represented.

## What this restores

`until_score: 10000` on `Remux-1080p - Anime`, matching the TRaSH default and the other four profiles, and removes the 8-line comment stating the wrong mechanism.

## Follow-up

The real driver appears to be `WEB-2160p`'s `until_quality: Bluray-2160p Remux` against a library that is mostly WEBDL-2160p (1439), Bluray-1080p Remux (1017) and WEBDL-1080p (840), with only 512 files at Bluray-2160p Remux. That is being investigated separately — along with a 44% download-failure rate (50 `downloadFailed` in the last 300 history events) — rather than changed on the same faulty reasoning.