### PR TITLE
docs(cleanuparr): correct OIDC Exclusive Mode rollback procedure

### DIFF
--- a/docs/superpowers/plans/2026-08-14-cleanuparr-authentik-oidc.md
+++ b/docs/superpowers/plans/2026-08-14-cleanuparr-authentik-oidc.md
@@ -354,7 +354,7 @@ Expected: `403`.
 
 Sign in once more from a fresh private window.
 
-This is the last point at which the recovery procedure is cheap. If login fails here, use the rescue-pod rollback in the spec to clear `oidc_exclusive_mode`.
+This is the last point at which the recovery procedure is cheap. If login fails here, clear `exclusiveMode` with the API-key rollback below — it works even while Exclusive Mode is active.
 
 - [ ] **Step 6: Update the spec status**
 
@@ -389,7 +389,26 @@ git push
 
 ## Rollback
 
-If Exclusive Mode locks you out, reverting `auth: false` does **not** help — forward-auth authenticates the request to Traefik, not the user to Cleanuparr. Clear the flag in the database instead. The Cleanuparr image has no `sqlite3`, so this needs a rescue pod:
+If Exclusive Mode locks you out, reverting `auth: false` does **not** help — forward-auth authenticates the request to Traefik, not the user to Cleanuparr.
+
+API-key authentication is **independent of Exclusive Mode**, so the flag can be cleared over the API without touching the database. Verified 2026-08-25: with Exclusive Mode on, password login returned `403` while `X-Api-Key` requests still returned `200`.
+
+```bash
+KEY=<Cleanuparr API key>   # Settings -> General, or GET /api/account/api-key
+BASE=https://cleanuparr.internal.starktastic.net
+
+# Echo the current object back with exclusiveMode flipped off. The masked client
+# secret ("••••••••") is preserved server-side by OidcConfig.IsPlaceholder(), so
+# a round-trip does not corrupt it.
+curl -s "$BASE/api/account/oidc" -H "X-Api-Key: $KEY" \
+  | python3 -c 'import json,sys; d=json.load(sys.stdin); d["exclusiveMode"]=False; print(json.dumps(d))' \
+  | curl -s -X PUT "$BASE/api/account/oidc" -H "X-Api-Key: $KEY" \
+      -H "Content-Type: application/json" --data-binary @-
+```
+
+Password login works again immediately; no restart required.
+
+Only if the API key is **also** lost, fall back to editing the database directly. The Cleanuparr image has no `sqlite3`, so this needs a rescue pod:
 
 ```bash
 kubectl -n media scale deploy/cleanuparr --replicas=0

--- a/docs/superpowers/specs/2026-08-14-cleanuparr-authentik-oidc-design.md
+++ b/docs/superpowers/specs/2026-08-14-cleanuparr-authentik-oidc-design.md
@@ -136,13 +136,22 @@ Either of these restores access:
 - Revert `auth: false` in `app.yaml`, restoring forward-auth. Note this alone
   does **not** cure an Exclusive Mode lockout: forward-auth authenticates the
   request to Traefik, not the user to Cleanuparr.
-- Clear Exclusive Mode in the database. `AuthController.Login` rejects
-  credential logins with HTTP 403 only while `oidc_exclusive_mode` is set, so
-  clearing that column re-enables the local password.
+- Clear Exclusive Mode. `AuthController.Login` rejects credential logins with
+  HTTP 403 only while `oidc_exclusive_mode` is set, so clearing it re-enables
+  the local password.
 
-The Cleanuparr image does not ship `sqlite3`, so the database edit needs a
-rescue pod. The `cleanuparr` PVC is `RWX`, but the deployment is still scaled
-down first so nothing writes to the SQLite WAL concurrently:
+**Preferred: clear it over the API.** API-key authentication is independent of
+Exclusive Mode, so no database access is needed. Verified 2026-08-25: with
+Exclusive Mode on, password login returned `403` while `X-Api-Key` requests
+still returned `200`. `PUT /api/account/oidc` with the current object and
+`exclusiveMode: false` is sufficient; the masked client secret (`••••••••`) is
+preserved server-side by `OidcConfig.IsPlaceholder()`. See the plan's Rollback
+section for the exact command.
+
+Only if the API key is also lost is a database edit required. The Cleanuparr
+image does not ship `sqlite3`, so that needs a rescue pod. The `cleanuparr` PVC
+is `RWX`, but the deployment is still scaled down first so nothing writes to the
+SQLite WAL concurrently:
 
 ```bash
 kubectl -n media scale deploy/cleanuparr --replicas=0


### PR DESCRIPTION
## What

Both the OIDC plan and the design spec documented a SQLite rescue pod as the *only* way out of an Exclusive Mode lockout. That is unnecessary and needlessly scary.

**API-key authentication is independent of Exclusive Mode**, so the flag can be cleared with a single `PUT /api/account/oidc` — no database access, no scaling the deployment down.

## Evidence

Verified 2026-08-25 against the live instance with Exclusive Mode enabled:

| Request | Result |
|---|---|
| Password login (`POST /api/auth/login`) | `403` |
| `X-Api-Key` request | `200` |

The GET→PUT round-trip is safe because `OidcConfig.IsPlaceholder()` (Cleanuparr v2.10.5) matches the masked secret `••••••••` and preserves the stored client secret server-side, so echoing the GET response back does not corrupt it.

## Changes

- Plan: replaced the rescue-pod procedure with the API-key command; rescue pod retained as a fallback for a lost API key.
- Plan: the Task 3 pointer at line 357 no longer sends the reader to the rescue-pod procedure.
- Spec: same correction, cross-referencing the plan for the exact command.

Docs only — no manifest or runtime change.